### PR TITLE
Replaced opn npm module with open because of deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See the [getting started documentation](https://developer.amazon.com/docs/ask-to
 
 ASK toolkit requires you to install and initialize the ASK CLI.
 
-1. Download and configure ASK CLI (recommend version 1.5.0). For more information, watch the [video](https://alexa.design/ask-cli-overview) and see the [documentation for configuring your AWS credentials](https://developer.amazon.com/docs/smapi/quick-start-alexa-skills-kit-command-line-interface.html).
+1. Download and configure ASK CLI (recommend version 1.7.14). For more information, watch the [video](https://alexa.design/ask-cli-overview) and see the [documentation for configuring your AWS credentials](https://developer.amazon.com/docs/smapi/quick-start-alexa-skills-kit-command-line-interface.html).
 
 2. To use the Alexa templates, [download Git](https://git-scm.com/downloads) and install it.
 

--- a/package.json
+++ b/package.json
@@ -240,7 +240,6 @@
         "@types/jsonfile": "^4.0.1",
         "@types/mocha": "^2.2.42",
         "@types/node": "^10.5.2",
-        "@types/opn": "^5.1.0",
         "@types/ramda": "^0.25.28",
         "@types/request": "^2.47.0",
         "@types/request-promise": "^4.1.41",
@@ -255,13 +254,13 @@
         "shx": "^0.3.2",
         "sinon": "^4.5.0",
         "tslint": "^5.10.0",
-        "typescript": "^2.8.3",
+        "typescript": "^3.6.3",
         "vscode": "^1.1.6"
     },
     "dependencies": {
         "execa": "^0.9.0",
         "jsonfile": "^4.0.0",
-        "opn": "^5.1.0",
+        "open": "^6.4.0",
         "ramda": "^0.25.0",
         "request": "^2.85.0",
         "request-promise": "^4.2.2",

--- a/src/commands/external/contactAlexaTeam.ts
+++ b/src/commands/external/contactAlexaTeam.ts
@@ -1,7 +1,7 @@
 'use strict';
 import * as vscode from 'vscode';
 import { EXTENSION_CONFIG, OPERATION, EXTERNAL_LINKS } from '../../utils/configuration';
-import opn = require('opn');
+import open = require('open');
 
 const optionUrlMap = new Map<string, string>();
 const CONTACT_ALEXA_DEVELOPER_SUPPORT = 'Contact Alexa Developer Support';
@@ -23,7 +23,7 @@ export const contactAlexaTeam = vscode.commands.registerCommand(`${EXTENSION_CON
             REPORT_ISSUE
         ]);
         if (pickedContactMethod) {
-            opn(<string>optionUrlMap.get(pickedContactMethod));
+            open(<string>optionUrlMap.get(pickedContactMethod));
         }
     }
 );

--- a/src/commands/external/openDeveloperPortal.ts
+++ b/src/commands/external/openDeveloperPortal.ts
@@ -1,10 +1,10 @@
 'use strict';
 import * as vscode from 'vscode';
 import { EXTENSION_CONFIG, OPERATION, EXTERNAL_LINKS } from '../../utils/configuration';
-import opn = require('opn');
+import open = require('open');
 
 export const openDevPortal = vscode.commands.registerCommand(`${EXTENSION_CONFIG.DEFAULT_PREFIX}.${OPERATION.EXTERNAL.DEV_PORTAL.EXTENSION_REGISTERED_NAME}`,
     () => {
-       opn(EXTERNAL_LINKS.DEV_PORTAL);
+       open(EXTERNAL_LINKS.DEV_PORTAL);
     }
 );

--- a/src/commands/external/openHelpDoc.ts
+++ b/src/commands/external/openHelpDoc.ts
@@ -1,10 +1,10 @@
 'use strict';
 import * as vscode from 'vscode';
 import { EXTENSION_CONFIG, OPERATION, EXTERNAL_LINKS } from '../../utils/configuration';
-import opn = require('opn');
+import open = require('open');
 
 export const openHelpDoc = vscode.commands.registerCommand(`${EXTENSION_CONFIG.DEFAULT_PREFIX}.${OPERATION.EXTERNAL.HELP_DOC.EXTENSION_REGISTERED_NAME}`,
     () => {
-       opn(EXTERNAL_LINKS.HELP_DOC);
+       open(EXTERNAL_LINKS.HELP_DOC);
     }
 );

--- a/src/utils/askCliHelper.ts
+++ b/src/utils/askCliHelper.ts
@@ -3,13 +3,13 @@
 import * as vscode from 'vscode';
 import * as shell from 'shelljs';
 import { ERROR_AND_WARNING, EXTERNAL_LINKS } from './configuration';
-import opn = require('opn');
+import open = require('open');
 
 export async function wasAskCliInstalled() {
     if (!shell.which('ask')) {
         const action = await vscode.window.showErrorMessage(ERROR_AND_WARNING.MISSING_ASK_CLI, ERROR_AND_WARNING.SUGGEST_INSTALL_CLI);
         if (action === ERROR_AND_WARNING.SUGGEST_INSTALL_CLI) {
-            opn(EXTERNAL_LINKS.ASK_CLI_INSTALL_DOC);
+            open(EXTERNAL_LINKS.ASK_CLI_INSTALL_DOC);
         }
         return false;
     }

--- a/src/utils/commandParametersHelper.ts
+++ b/src/utils/commandParametersHelper.ts
@@ -34,11 +34,11 @@ export function findSkillId(profile: string): string|undefined {
     } else {
         const config = jsonfile.readFileSync(configPath);
         const skillIdJsonPath = R.path(['deploy_settings', profile, 'skill_id']);
-        const skillId = skillIdJsonPath(config);
+        const skillId = skillIdJsonPath(config) as string;
         if (skillId) {
             return skillId.toString();
         } else {
-            return warnMessage('valid "skill ID" value in .ask/confg');
+            return warnMessage('valid "skill ID" value in .ask/config');
         }
     }
 }

--- a/src/utils/commandRunner.ts
+++ b/src/utils/commandRunner.ts
@@ -19,7 +19,7 @@ export class CommandRunner {
     /**
      * Run commands in the VS Code integrated terminal.
      * @param {ICommand} input
-     * @param {string} terminalName defaults to EXTENSION_CONFIG.IntegratedTermianlName
+     * @param {string} terminalName defaults to EXTENSION_CONFIG.IntegratedTerminalName
      */
     public static runCommand(input: ICommand, terminalName: string = EXTENSION_CONFIG.INTEGRATED_TERMINAL_NAME): void {
         if (!input.command) {

--- a/src/utils/lowLevelCommandBuilder.ts
+++ b/src/utils/lowLevelCommandBuilder.ts
@@ -34,7 +34,7 @@ export class LowLevelCommandBuilder {
                     break;
                     
                 default:
-                    throw new Error(`Invilad 'queryInputMethod' for parameter '${requiredParam.parameterName}'.`);
+                    throw new Error(`Invalid 'queryInputMethod' for parameter '${requiredParam.parameterName}'.`);
             }
 
 
@@ -57,7 +57,7 @@ export class LowLevelCommandBuilder {
                 // if the user didn't input anything, the builder will omit this parameter.
                     continue;
                 } 
-                const errorMessage = `Proccess aborted due to ${requiredParam.parameterName}, ${requiredParam.quickPick!.items.toString()} is omitted.`;
+                const errorMessage = `Process aborted due to ${requiredParam.parameterName}, ${requiredParam.quickPick!.items.toString()} is omitted.`;
                 throw new Error(errorMessage);
             }
         }
@@ -102,7 +102,7 @@ export class LowLevelCommandBuilder {
             return !!item;
         });
         const noPreDefinedParameters = removeUndefinedValueFromList(<IRequiredInputParameter[]>getConfigValueIfPossible(requiredParameters));
-        // tuple appoach.
+        // tuple approach.
         return [defaultConfigValueMap, noPreDefinedParameters];
     }
     

--- a/src/utils/profileManager.ts
+++ b/src/utils/profileManager.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 import { CommandRunner, ICommand } from './commandRunner';
 import { ERROR_AND_WARNING, EXTERNAL_LINKS } from './configuration';
-import opn = require('opn');
+import open = require('open');
 const execa = require('execa');
 
 const NULL_AWS_PROFILE = '** NULL **';
@@ -12,8 +12,8 @@ export class ProfileManager {
     private static cachedProfileList: IProfile[] = [];
 
     /**
-     * initalized the profile manager. The profile manager will cache the profile list
-     * if they are existed, or show an error message with an option to initaizled the ASK CLI
+     * Initialize the profile manager. The profile manager will cache the profile list
+     * if they exist, or show an error message with an option to initialize the ASK CLI
      */
     public static init() {
         try {
@@ -79,12 +79,12 @@ export class ProfileManager {
             CommandRunner.runCommand( <ICommand>{
                 command: 'init'
             });
-            opn(EXTERNAL_LINKS.INIT_COMMAND_DOC);
+            open(EXTERNAL_LINKS.INIT_COMMAND_DOC);
         }
     }
 
     /**
-     * check whether aws is configured in atleast one of the cached profiles
+     * check whether aws is configured in at least one of the cached profiles
      */
     public static isAnyAwsConfiguredInProfiles() {
         for (let entry of this.cachedProfileList) {
@@ -101,7 +101,7 @@ export class ProfileManager {
     public static async showAwsCredentialsMissingNotice() {
         const action = await vscode.window.showWarningMessage(ERROR_AND_WARNING.CHECK_AWS_PROFILE_EXISTS.MISSING_AWS_PROFILE, ERROR_AND_WARNING.CHECK_AWS_PROFILE_EXISTS.BUTTON_MESSAGE);
         if (action === ERROR_AND_WARNING.CHECK_AWS_PROFILE_EXISTS.BUTTON_MESSAGE) {
-            opn(EXTERNAL_LINKS.INIT_COMMAND_DOC);
+            open(EXTERNAL_LINKS.INIT_COMMAND_DOC);
         }
     }
 

--- a/src/utils/statusBarHelper.ts
+++ b/src/utils/statusBarHelper.ts
@@ -9,8 +9,8 @@ import * as vscode from 'vscode';
  * @param {string} tooltip The description when hovering the button.
  * @return {vscode.StatusBarItem}
  */
-export function createStatusBarItem(priority: number, commandName: string, iconText: string, tooltip: string, aligment: vscode.StatusBarAlignment = vscode.StatusBarAlignment.Left): vscode.StatusBarItem {
-    const item = vscode.window.createStatusBarItem(aligment, priority);
+export function createStatusBarItem(priority: number, commandName: string, iconText: string, tooltip: string, alignment: vscode.StatusBarAlignment = vscode.StatusBarAlignment.Left): vscode.StatusBarItem {
+    const item = vscode.window.createStatusBarItem(alignment, priority);
     item.command = commandName;
     item.text = iconText;
     item.tooltip = tooltip;


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
Since [opn](https://www.npmjs.com/package/opn) module is deprecated, replacing it with [open](https://www.npmjs.com/package/open). 
Also corrected minor spell mistakes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
