### PR TITLE
fix: Change manifest json validatio's s3 bucket to a new one which ho…

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
             },
             {
                 "fileMatch": "*/skill.json",
-                "url": "https://s3.amazonaws.com/ask-json-schema/Manifest/manifest.json"
+                "url": "https://ask-json-schemas.s3-us-west-2.amazonaws.com/Manifest/skillManifestJsonSchema.json"
             },
             {
                 "fileMatch": "**/isps/entitlement/*.json",


### PR DESCRIPTION
…st the latest schema

*Issue #, if available:*
#10
*Description of changes:*
The json validation for manifest.json is out of date. Deprecated previous s3 bucket and switch to a new one which host the latest json schema.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
