### PR TITLE
Update code/docs to specify usage of CLI v1 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ See the [getting started documentation](https://developer.amazon.com/docs/ask-to
 
 ## Requirements
 
-ASK toolkit requires you to install and initialize the ASK CLI.
+ASK toolkit requires you to install and initialize the ASK CLI v1.
 
-1. Download and configure ASK CLI (recommend version 1.7.14). For more information, watch the [video](https://alexa.design/ask-cli-overview) and see the [documentation for configuring your AWS credentials](https://developer.amazon.com/docs/smapi/quick-start-alexa-skills-kit-command-line-interface.html).
+1. Download and configure ASK CLI v1(recommend version 1.7.23). For more information, watch the [video](https://alexa.design/ask-cli-overview) and see the [documentation for configuring your AWS credentials](https://developer.amazon.com/docs/smapi/quick-start-alexa-skills-kit-command-line-interface.html).
 
 2. To use the Alexa templates, [download Git](https://git-scm.com/downloads) and install it.
 

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
             },
             {
                 "command": "ask.init",
-                "title": "Initialize / Configure the ASK CLI",
+                "title": "Initialize / Configure the ASK CLI v1",
                 "category": "ASK"
             },
             {

--- a/src/utils/askCliHelper.ts
+++ b/src/utils/askCliHelper.ts
@@ -2,15 +2,11 @@
 
 import * as vscode from 'vscode';
 import * as shell from 'shelljs';
-import { ERROR_AND_WARNING, EXTERNAL_LINKS } from './configuration';
-import open = require('open');
+import { ERROR_AND_WARNING } from './configuration';
 
 export async function wasAskCliInstalled() {
     if (!shell.which('ask')) {
-        const action = await vscode.window.showErrorMessage(ERROR_AND_WARNING.MISSING_ASK_CLI, ERROR_AND_WARNING.SUGGEST_INSTALL_CLI);
-        if (action === ERROR_AND_WARNING.SUGGEST_INSTALL_CLI) {
-            open(EXTERNAL_LINKS.ASK_CLI_INSTALL_DOC);
-        }
+        vscode.window.showErrorMessage(ERROR_AND_WARNING.MISSING_ASK_CLI);
         return false;
     }
     return true;

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -368,11 +368,11 @@ export const VSCODE_SETTING_CONFIGURATION = {
 
 
 export const ERROR_AND_WARNING = {
-    EMPTY_PROFILE_MESSAGE: 'ask-cli has not set up any profiles yet',
-    SUGGEST_INIT_CLI: 'ASK Command Line Inferface (ASK CLI) is not initialized with your Amazon developer account credentials.',
-    INIT_CLI_ACTION: 'Initialize the ASK CLI.',
-    MISSING_ASK_CLI: 'ASK Command Line Interface (ASK CLI) is not installed. The toolkit requires ASK CLI to execute the commands.',
-    SUGGEST_INSTALL_CLI: 'See the ASK CLI installation guide.',
+    EMPTY_PROFILE_MESSAGE: 'ask-cli v1 has not set up any profiles yet',
+    SUGGEST_INIT_CLI: 'ASK Command Line Interface (ASK CLI v1) is not initialized with your Amazon developer account credentials.',
+    INIT_CLI_ACTION: 'Initialize the ASK CLI v1.',
+    MISSING_ASK_CLI: 'ASK Command Line Interface (ASK CLI v1) is not installed. The toolkit requires ASK CLI v1 version to execute the commands.\nPlease run npm install -g ask-cli@1 get to the latest CLI v1 version.',
+    SUGGEST_INSTALL_CLI: 'See the ASK CLI v1 installation guide.',
     QUICK_PICK_PLACE_HOLDER: 'Please choose a profile. (You can set up a default profile in user\'s setting with \'ask.profile\').',
     CHECK_WORKSPACE_EXISTS: {
         CREATE_CLONE_ERROR_MESSAGE:'No workspace detected.\nOpen a workspace folder in which you want to create or clone your skill project and then run the command again.',

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -371,7 +371,7 @@ export const ERROR_AND_WARNING = {
     EMPTY_PROFILE_MESSAGE: 'ask-cli v1 has not set up any profiles yet',
     SUGGEST_INIT_CLI: 'ASK Command Line Interface (ASK CLI v1) is not initialized with your Amazon developer account credentials.',
     INIT_CLI_ACTION: 'Initialize the ASK CLI v1.',
-    MISSING_ASK_CLI: 'ASK Command Line Interface (ASK CLI v1) is not installed. The toolkit requires ASK CLI v1 version to execute the commands.\nPlease run npm install -g ask-cli@1 get to the latest CLI v1 version.',
+    MISSING_ASK_CLI: 'ASK Command Line Interface (ASK CLI v1) is not installed. The toolkit requires ASK CLI v1 version to execute the commands.\nPlease run \"npm install -g ask-cli@1\" get to the latest CLI v1 version.',
     SUGGEST_INSTALL_CLI: 'See the ASK CLI v1 installation guide.',
     QUICK_PICK_PLACE_HOLDER: 'Please choose a profile. (You can set up a default profile in user\'s setting with \'ask.profile\').',
     CHECK_WORKSPACE_EXISTS: {

--- a/src/utils/profileManager.ts
+++ b/src/utils/profileManager.ts
@@ -13,7 +13,7 @@ export class ProfileManager {
 
     /**
      * Initialize the profile manager. The profile manager will cache the profile list
-     * if they exist, or show an error message with an option to initialize the ASK CLI
+     * if they exist, or show an error message with an option to initialize the ASK CLI v1
      */
     public static init() {
         try {
@@ -32,13 +32,13 @@ export class ProfileManager {
                 this.showAwsCredentialsMissingNotice();
             }
         } catch (error) {
-            throw new Error('ASK CLI is not functional. ' + error.message);
+            throw new Error('ASK CLI v1 is not functional. ' + error.message);
         }
     }
 
     /**
      * parse the profile from CLI to a list of profile object that can be stored.
-     * @param profileString the output string from ASK CLI. i.e., [askProfile]   "awsProfile".
+     * @param profileString the output string from ASK CLI v1. i.e., [askProfile]   "awsProfile".
      */
     private static extractProfilesFromCliOutput(profileString:string) {
         const profiles = profileString.split(/\]/);
@@ -60,8 +60,8 @@ export class ProfileManager {
     }
 
     /**
-     * Remove the first line (header) and last line (empty spaces) from the ASK CLI output list.
-     * @param input entire output from ASK CLI
+     * Remove the first line (header) and last line (empty spaces) from the ASK CLI v1 output list.
+     * @param input entire output from ASK CLI v1
      */
     private static takeOutHeaderAndEnding(input: string) {
         if (input.length === 0 || input.includes('Associated AWS Profile')) {


### PR DESCRIPTION
*Description of changes:*

Since CLI released a major version [v2.0.1](https://www.npmjs.com/package/ask-cli) recently. 
VSCode still depends on CLI v1 major build to execute commands so updating the errorMessage to instruct on installing CLI v1 version.

*Screenshot:*
<img width="463" alt="Screen Shot 2020-04-15 at 2 38 23 PM" src="https://user-images.githubusercontent.com/3158685/79391921-49648d00-7f27-11ea-86d2-6ef1ac47740d.png">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
