### PR TITLE
Added ASK CLI v2 configure command

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
         "onCommand:ask.deployIspOnly",
         "onCommand:ask.simulate",
         "onCommand:ask.diff",
-        "onCommand:ask.dialog"
+        "onCommand:ask.dialog",
+        "onCommand:ask.configure"
     ],
     "main": "./out/src/extension",
     "contributes": {
@@ -139,7 +140,7 @@
             },
             {
                 "command": "ask.init",
-                "title": "Initialize / Configure the ASK CLI v1",
+                "title": "Initialize a new or existing Alexa Skill project",
                 "category": "ASK"
             },
             {
@@ -165,6 +166,11 @@
             {
                 "command": "ask.dialog",
                 "title": "(Beta)simulate your skill via interactive dialog with Alexa",
+                "category": "ASK"
+            },
+            {
+                "command": "ask.configure",
+                "title": "Configure ASK (and AWS) profiles and credentials",
                 "category": "ASK"
             }
         ],

--- a/src/commands/highLevelCommands/configure.ts
+++ b/src/commands/highLevelCommands/configure.ts
@@ -1,0 +1,33 @@
+'use strict';
+import * as vscode from "vscode";
+import { CommandRunner, ICommand } from "../../utils/commandRunner";
+import { EXTENSION_CONFIG, OPERATION } from "../../utils/configuration";
+import { wasAskCliInstalled } from "../../utils/askCliHelper";
+import { ProfileManager } from "../../utils/profileManager";
+
+const COMMAND_NAME = EXTENSION_CONFIG.DEFAULT_PREFIX + '.' + OPERATION.HIGH_LEVEL.CONFIGURE.EXTENSION_REGISTERED_NAME;
+
+/**
+ * Implements the `ask configure` command.  This has taken over for the `ask init` command with regards to 
+ * authentication and profile configuration. 
+ * 
+ * Which may not be possible, as v2 of the `ask cli` doesn't actually have the `--list-profiles` 
+ * argument.
+ * 
+ * @since v2.0
+ * @see {@link https://developer.amazon.com/en-US/docs/alexa/smapi/ask-cli-command-reference.html#configure-command}
+ */
+export const configure = vscode.commands.registerCommand(COMMAND_NAME, async () => {
+    if (!await wasAskCliInstalled()) {
+        return;
+    }
+    const configureCommand =  <ICommand> {
+        command: OPERATION.HIGH_LEVEL.CONFIGURE.COMMAND,
+        commandParameters: new Map<string, any>()
+    };
+    CommandRunner.runCommand(configureCommand);
+
+    // no matter `ask configure` successful or not, the cached profile will be empty
+    // refresh cache method will get triggered next time when the extension search for profiles.
+    ProfileManager.clearCachedProfile();
+});

--- a/src/commands/highLevelCommands/init.ts
+++ b/src/commands/highLevelCommands/init.ts
@@ -7,6 +7,11 @@ import { ProfileManager } from "../../utils/profileManager";
 
 const COMMAND_NAME = EXTENSION_CONFIG.DEFAULT_PREFIX + '.' + OPERATION.HIGH_LEVEL.INITIALIZATION.EXTENSION_REGISTERED_NAME;
 
+/**
+ * Implements the `ask init` command.  Currently available options:
+ * 
+ * @see {@link https://developer.amazon.com/en-US/docs/alexa/smapi/ask-cli-command-reference.html#init-command}
+ */
 export const init = vscode.commands.registerCommand(COMMAND_NAME, async () => {
     if (!await wasAskCliInstalled()) {
         return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,7 @@ import { diff } from './commands/highLevelCommands/diff';
 import { contactAlexaTeam } from './commands/external/contactAlexaTeam';
 import { doesWorkSpaceExist, askUserToPickAWorkspace } from './utils/highLevelCommandHelper';
 import { dialog } from './commands/highLevelCommands/dialog';
+import { configure } from './commands/highLevelCommands/configure';
 
 export async function activate(context: vscode.ExtensionContext) {
     if (!await wasAskCliInstalled()) {
@@ -61,7 +62,8 @@ function registerCommands(context: vscode.ExtensionContext) {
         newWithTemplate,
         init,
         diff,
-        dialog
+        dialog,
+        configure
     );
     context.subscriptions.push(
         openDevPortal,

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -61,6 +61,10 @@ export const OPERATION = {
         DIALOG: {
             COMMAND: 'dialog',
             EXTENSION_REGISTERED_NAME: 'dialog'
+        },
+        CONFIGURE: {
+            COMMAND: 'configure',
+            EXTENSION_REGISTERED_NAME: 'configure'
         }
     },
     LOW_LEVEL: {

--- a/src/utils/profileManager.ts
+++ b/src/utils/profileManager.ts
@@ -17,7 +17,7 @@ export class ProfileManager {
      */
     public static init() {
         try {
-            const listProfileOutput = execa.shellSync('ask init -l');
+            const listProfileOutput = execa.shellSync('ask configure -l');
             if ((listProfileOutput.stderr && listProfileOutput.stderr.includes(ERROR_AND_WARNING.EMPTY_PROFILE_MESSAGE)) || listProfileOutput.stdout.trim().length === 0) {
                 return;
             }


### PR DESCRIPTION
*Issue #, if available:*
#15 - Happened to be playing around with this prior to the task being opened.

*Description of changes:*
Started the process of updating the extension for use with ASK-CLI v2.  There are still a lot of changes required, but the `init` and `configure` are now more inline with the ASK-CLI documentation.

**NOTE** - this also requires another pull request for the ASK-CLI to re-incorporate the `ask configure --list-profiles` option, which was removed in v0.8.0. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
