### PR TITLE
Change permissions on profile config file

### DIFF
--- a/package.json
+++ b/package.json
@@ -243,8 +243,8 @@
         ]
     },
     "scripts": {
-        "vscode:prepublish": "webpack --mode production",
-        "webpack": "webpack --mode development",
+        "vscode:prepublish": "npm run compile && webpack --mode production",
+        "webpack": "npm run compile && webpack --mode development",
         "webpack-dev": "webpack --mode development --watch",
         "test-compile": "tsc -p ./",
         "compile": "shx rm -rf ./out/ && shx rm -rf ./dist/ && tsc -p ./",

--- a/src/runtime/lib/utils/constants.ts
+++ b/src/runtime/lib/utils/constants.ts
@@ -17,3 +17,17 @@ export const EXTENSION_STATE_KEY = {
     ASK_LWA_TOKEN_HOST: 'ASK_LWA_TOKEN_HOST',
     ASK_SMAPI_SERVER_BASE_URL: 'ASK_SMAPI_SERVER_BASE_URL'
 };
+
+export const FILE_PATH = {
+    ASK: {
+        HIDDEN_FOLDER: '.ask',
+        PROFILE_FILE: 'cli_config'
+    }
+};
+
+export const CONFIGURATION = {
+    FILE_PERMISSION: {
+        USER_READ_WRITE: '0600'
+    },
+    JSON_DISPLAY_INTENT: 2,
+};

--- a/src/runtime/lib/utils/profileHelper.ts
+++ b/src/runtime/lib/utils/profileHelper.ts
@@ -8,14 +8,15 @@ import { writeFileSync } from 'jsonfile';
 import { Hash } from 'crypto';
 import { ExtensionContext, window } from 'vscode';
 import { isTokenExpired, refreshToken } from './oauthWrapper';
-import { AUTH, EXTENSION_STATE_KEY } from './constants';
+import { AUTH, EXTENSION_STATE_KEY, CONFIGURATION, FILE_PATH } from './constants';
 import { SmapiClientFactory } from '../smapiClientFactory';
 import * as model from 'ask-smapi-model';
 import { writeToProperty } from './jsonUtility';
 import { Logger } from '../../../logger';
 
 export function listExistingProfileNames(): string[]|null {
-    const askConfig: string = join(homedir(), '.ask', 'cli_config');
+    const askConfig: string = join(
+        homedir(), FILE_PATH.ASK.HIDDEN_FOLDER, FILE_PATH.ASK.PROFILE_FILE);
     if (!existsSync(askConfig)) {
         return null;
     }
@@ -31,18 +32,26 @@ export function listExistingProfileNames(): string[]|null {
 }
 
 export function createConfigFileIfNotExists(): void {
-    const askConfig: string = join(homedir(), '.ask', 'cli_config');
+    const askConfig: string = join(
+        homedir(), FILE_PATH.ASK.HIDDEN_FOLDER, FILE_PATH.ASK.PROFILE_FILE);
     if (!existsSync(askConfig)) {
-        const askFolder: string = join(homedir(), '.ask');
+        const askFolder: string = join(homedir(), FILE_PATH.ASK.HIDDEN_FOLDER);
         if (!existsSync(askFolder)) {
             mkdirSync(askFolder);
         }
-        writeFileSync(askConfig, { profiles: {} }, { spaces: 2 });
+        writeFileSync(
+            askConfig, 
+            { profiles: {} }, 
+            { 
+                spaces: CONFIGURATION.JSON_DISPLAY_INTENT, 
+                mode: CONFIGURATION.FILE_PERMISSION.USER_READ_WRITE 
+            });
     }
 }
 
 export function getProfileInfo(profile: string): Hash | null {
-    const askConfig = join(homedir(), '.ask', 'cli_config');
+    const askConfig = join(
+        homedir(), FILE_PATH.ASK.HIDDEN_FOLDER, FILE_PATH.ASK.PROFILE_FILE);
     if (!existsSync(askConfig)) {
         return null;
     }
@@ -74,7 +83,8 @@ export async function isProfileAuth(context: ExtensionContext): Promise<boolean>
 }
 
 export function deleteProfile(profileName: string): boolean {
-    const askConfig: string = join(homedir(), '.ask', 'cli_config');
+    const askConfig: string = join(
+        homedir(), FILE_PATH.ASK.HIDDEN_FOLDER, FILE_PATH.ASK.PROFILE_FILE);
     if (!existsSync(askConfig)) {
         return false;
     }
@@ -83,7 +93,8 @@ export function deleteProfile(profileName: string): boolean {
 
 export async function setVendorId(profile: string, context: ExtensionContext): Promise<boolean> {
     const vendors: model.v1.vendorManagement.Vendors = await SmapiClientFactory.getInstance(profile, context).getVendorListV1();
-    const configPath = join(homedir(), '.ask', 'cli_config');
+    const configPath = join(
+        homedir(), FILE_PATH.ASK.HIDDEN_FOLDER, FILE_PATH.ASK.PROFILE_FILE);
     const propertyPathArray = ['profiles', profile, 'vendor_id'];
     if (vendors.vendors && vendors.vendors.length > 0) {
         const selectedVendor = vendors.vendors.length > 1 ? await selectVendorId(vendors.vendors, context) : vendors.vendors[0].id;
@@ -137,11 +148,12 @@ export function resolveVendorId(profileName: string): string {
     if (profileName === AUTH.PLACEHOLDER_ENVIRONMENT_VAR_PROFILE_NAME) {
         vendorId = process.env.ASK_VENDOR_ID;
     } else {
-        const askConfig: string = join(homedir(), '.ask', 'cli_config');
+        const askConfig: string = join(
+            homedir(), FILE_PATH.ASK.HIDDEN_FOLDER, FILE_PATH.ASK.PROFILE_FILE);
         if (existsSync(askConfig)) {
             vendorId = getProperty(askConfig, ['profiles', profileName, 'vendor_id']);
         } else {
-            throw new Error('Please make sure $HOME/.ask/cli_config exists.');
+            throw new Error(`Please make sure ${askConfig} exists.`);
         }
     }
     return vendorId;


### PR DESCRIPTION
**Description**

This commit contains the following changes:

- The profile configuration file was created on [default permissions](https://nodejs.org/api/fs.html#fs_fs_writefile_file_data_options_callback)
(`0666`) which had more access than needed. Changed it to only have
read write permissions for current user (`0600`), for more secure
access.
- Moved some hard coded strings in profile helper, to constants file
and reformated profile helper.
- Changed extension run script to compile before doing webpack.

**Testing**

- Tested by moving the existing profile file and restarting the extension to go through the sign in process again and checked the newly created profile file permissions.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
