### PR TITLE
feat: Add telemetry for hosted skills clone, open URLs, and SMAPI user agent

### DIFF
--- a/src/askContainer/commands/cloneSkillFromConsole.ts
+++ b/src/askContainer/commands/cloneSkillFromConsole.ts
@@ -1,17 +1,16 @@
 import {
     SmapiResource, AbstractCommand, CommandContext
 } from '../../runtime';
-
+ 
 import { SkillInfo } from '../../models/types';
 import { executeClone } from '../../utils/cloneSkillHelper';
 import { Logger } from '../../logger';
-
-export class CloneSkillCommand extends AbstractCommand<void> {
-
+ 
+export class CloneSkillFromConsoleCommand extends AbstractCommand<void> {
     constructor() {
-        super('askContainer.skillsConsole.cloneSkill');
+        super('askContainer.skillsConsole.cloneSkillFromConsole');
     }
-
+ 
     async execute(context: CommandContext, skillInfo: SmapiResource<SkillInfo>): Promise<void> {
         Logger.debug(`Calling method: ${this.commandName}, args: `, skillInfo);
         await executeClone(context, skillInfo);

--- a/src/askContainer/treeViews/treeViewProviders/helpViewProvider.ts
+++ b/src/askContainer/treeViews/treeViewProviders/helpViewProvider.ts
@@ -53,7 +53,7 @@ export class HelpViewProvider implements vscode.TreeDataProvider<PluginTreeItem<
             {
                 title: 'openUrl',
                 command: 'ask.container.openUrl',
-                arguments: [EXTERNAL_LINKS.RELEASE_UPDATES, true],
+                arguments: [EXTERNAL_LINKS.RELEASE_UPDATES, true, {CommandType: 'RELEASE_UPDATES'}],
             }, undefined, ContextValueTypes.SKILL,
         ));
     
@@ -75,7 +75,7 @@ export class HelpViewProvider implements vscode.TreeDataProvider<PluginTreeItem<
             vscode.TreeItemCollapsibleState.None, {
                 title: 'openUrl',
                 command: 'ask.container.openUrl',
-                arguments: [EXTERNAL_LINKS.TOOLS_DOCS.CLI, true],
+                arguments: [EXTERNAL_LINKS.TOOLS_DOCS.CLI, true, {CommandType: 'TOOLS_DOCS_CLI'}],
             }, undefined,
             ContextValueTypes.SKILL,
         ));
@@ -85,7 +85,7 @@ export class HelpViewProvider implements vscode.TreeDataProvider<PluginTreeItem<
             vscode.TreeItemCollapsibleState.None, {
                 title: 'openUrl',
                 command: 'ask.container.openUrl',
-                arguments: [EXTERNAL_LINKS.TOOLS_DOCS.VSCODE, true],
+                arguments: [EXTERNAL_LINKS.TOOLS_DOCS.VSCODE, true, {CommandType: 'TOOLS_DOCS_VSCODE'}],
             }, undefined,
             ContextValueTypes.SKILL,
         ));
@@ -103,7 +103,7 @@ export class HelpViewProvider implements vscode.TreeDataProvider<PluginTreeItem<
             {
                 title: 'openUrl',
                 command: 'ask.container.openUrl',
-                arguments: [EXTERNAL_LINKS.TOOLS_DOCS.ASK_SDK, true],
+                arguments: [EXTERNAL_LINKS.TOOLS_DOCS.ASK_SDK, true, {CommandType: 'TOOLS_DOCS_ASK_SDK'}],
             }, undefined,
             ContextValueTypes.SKILL,
         ));
@@ -113,7 +113,7 @@ export class HelpViewProvider implements vscode.TreeDataProvider<PluginTreeItem<
             vscode.TreeItemCollapsibleState.None, {
                 title: 'openUrl',
                 command: 'ask.container.openUrl',
-                arguments: [EXTERNAL_LINKS.TOOLS_DOCS.SMAPI_SDK, true],
+                arguments: [EXTERNAL_LINKS.TOOLS_DOCS.SMAPI_SDK, true, {CommandType: 'TOOLS_DOCS_SMAPI_SDK'}],
             }, undefined,
             ContextValueTypes.SKILL,
         ));

--- a/src/askContainer/treeViews/treeViewProviders/skillActionsViewProvider.ts
+++ b/src/askContainer/treeViews/treeViewProviders/skillActionsViewProvider.ts
@@ -159,7 +159,7 @@ export class SkillActionsViewProvider implements vscode.TreeDataProvider<PluginT
                     {
                         title: 'openUrl',
                         command: 'ask.container.openUrl',
-                        arguments: [getSimulatorLink(skillId, skillDetails.defaultLocale)],
+                        arguments: [getSimulatorLink(skillId, skillDetails.defaultLocale), {CommandType: 'SIMULATOR'}],
                     }, undefined,
                     ContextValueTypes.SKILL,
                 ),
@@ -294,7 +294,7 @@ export class SkillActionsViewProvider implements vscode.TreeDataProvider<PluginT
                 {
                     title: 'openUrl',
                     command: 'ask.container.openUrl',
-                    arguments: [getIModelGeneratorLink(skillId, skillDetails.defaultLocale)],
+                    arguments: [getIModelGeneratorLink(skillId, skillDetails.defaultLocale), {CommandType: 'IM_EDITOR'}],
                 }, undefined,
                 ContextValueTypes.SKILL,
             ),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import { registerCommands as apiRegisterCommands, AbstractWebView, Utils } from './runtime';
 
 import { CloneSkillCommand } from './askContainer/commands/cloneSkill';
+import { CloneSkillFromConsoleCommand } from './askContainer/commands/cloneSkillFromConsole';
 import { DeploySkillCommand } from './askContainer/commands/deploySkill';
 import { SyncInteractionModelCommand } from './askContainer/commands/syncInteractionModel';
 import { SyncManifestCommand } from './askContainer/commands/syncManifest';
@@ -59,7 +60,7 @@ function registerCommands(context: vscode.ExtensionContext): void {
         new InitCommand(profileManager), new GetToolkitInfoCommand(),
         new ViewAllSkillsCommand(), new CreateSkillCommand(createSkill),
         new CloneSkillCommand(), new ChangeProfileCommand(), new AccessTokenCommand(),
-        new DebugAdapterPathCommand()]);
+        new DebugAdapterPathCommand(), new CloneSkillFromConsoleCommand()]);
 }
 
 async function registerSkillActionComponents(context: vscode.ExtensionContext): Promise<void> {

--- a/src/runtime/lib/API.ts
+++ b/src/runtime/lib/API.ts
@@ -25,7 +25,7 @@ export function registerCommands(context: ExtensionContext, commands: GenericCom
 }
 
 export abstract class AbstractCommand<T> implements GenericCommand, Command {
-    // Need this for adding AbstractCommand as a valid type t
+    // Need this for adding AbstractCommand as a valid type
     title: string;
     command: string;
     tooltip?: string;
@@ -51,7 +51,8 @@ export abstract class AbstractCommand<T> implements GenericCommand, Command {
     }
 
     private async _invoke(commandName: string, ...args: any[]): Promise<T> {
-        const commandType = 'command';
+        const typeArg = args.find(arg => arg.CommandType);
+        const commandType = typeArg ? typeArg.CommandType : 'command';
         const telemetryClient = new TelemetryClient({});
         let output: any;
 

--- a/src/runtime/lib/smapiClientFactory.ts
+++ b/src/runtime/lib/smapiClientFactory.ts
@@ -1,16 +1,17 @@
+import * as vscode from 'vscode';
 import { RefreshTokenConfig, CustomSmapiClientBuilder } from "ask-smapi-sdk";
 import * as smapiModel from 'ask-smapi-model';
 import { CredentialsManager, Credentials } from "./credentialsManager";
 import { resolver } from "./utils/configuration";
-import { ExtensionContext } from "vscode";
 import { AUTH } from "./utils/constants";
+import { EXTENSION_ID } from '../../constants';
 
 export class SmapiClientFactory {
     private static readonly profileInstanceMap: Map<String, smapiModel.services.skillManagement.SkillManagementServiceClient> = new Map();
 
     private constructor() { }
 
-    public static getInstance(profile: string, context: ExtensionContext): smapiModel.services.skillManagement.SkillManagementServiceClient {
+    public static getInstance(profile: string, context: vscode.ExtensionContext): smapiModel.services.skillManagement.SkillManagementServiceClient {
         let smapiClient = this.profileInstanceMap.get(profile);
         if (!smapiClient) {
             const authConfig: Credentials = CredentialsManager.getCredentials(profile);
@@ -19,10 +20,12 @@ export class SmapiClientFactory {
                 clientSecret: authConfig.clientSecret,
                 refreshToken: authConfig.refreshToken
             };
+            const pluginVersion: string = vscode.extensions.getExtension(EXTENSION_ID)?.packageJSON.version;
             smapiClient = new CustomSmapiClientBuilder()
                 .withApiEndpoint(resolver([process.env.ASK_SMAPI_SERVER_BASE_URL, undefined]))
                 .withAuthEndpoint(resolver([process.env.ASK_LWA_TOKEN_HOST, AUTH.DEFAULT_ASK_LWA_TOKEN_HOST]))
                 .withRefreshTokenConfig(refreshTokenConfig)
+                .withCustomUserAgent(`alexa-skills-kit-toolkit/${pluginVersion}`)
                 .client();
             this.profileInstanceMap.set(profile, smapiClient);
         }

--- a/src/utils/urlHandlers.ts
+++ b/src/utils/urlHandlers.ts
@@ -45,7 +45,7 @@ export async function hostedSkillsClone(uri: vscode.Uri, context: vscode.Extensi
             const targetSkill: SkillSummary  = listSkills.skills![0];
             if (targetSkill) {
                 vscode.commands.executeCommand(
-                    'askContainer.skillsConsole.cloneSkill', new SmapiResource<SkillInfo>(
+                    'askContainer.skillsConsole.cloneSkillFromConsole', new SmapiResource<SkillInfo>(
                         new SkillInfo(targetSkill, true, hostedSkillMetadata), targetSkillId));
                 return;
             }


### PR DESCRIPTION
**Description**

This commit introduces the following changes :

- A new cloneSkillFromConsole command which handles cloning the hosted skills
from developer console.
- Reformatting common logic from cloneSkill and cloneSkillFromConsole command
to a new utility function.
- Setting the user agent specific to extension for SMAPI SDK initialization.
- Setting correct telemetry command names for open URL commands.

**Testing**

- Tested with cloning skill directly and from console, to see that the new process is triggered and skills cloning works.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
