### PR TITLE
fix: fix testRunner script and revert some await usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
         "compile": "shx rm -rf ./out/ && shx rm -rf ./dist/ && tsc -p ./",
         "lint": "eslint src --ext ts",
         "watch": "tsc -watch -p ./",
-        "pretest": "npm run compile && npm run lint",
+        "pretest": "npm run compile",
         "test": "node ./out/test/runTest.js"
     },
     "devDependencies": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -65,7 +65,7 @@ function registerCommands(context: vscode.ExtensionContext): void {
 async function registerSkillActionComponents(context: vscode.ExtensionContext): Promise<void> {
     // Register skill specific components, if skill is detected
     const skillFolders = await findSkillFoldersInWs();
-    await context.workspaceState.update(EXTENSION_STATE_KEY.WS_SKILLS, skillFolders);
+    void context.workspaceState.update(EXTENSION_STATE_KEY.WS_SKILLS, skillFolders);
 
     if (skillFolders.length > 0) {
         const deploySkill: DeploySkillWebview = new DeploySkillWebview('Deploy skill', 'deploySkill', context);
@@ -142,7 +142,7 @@ function registerEventHandlers(context: vscode.ExtensionContext): void {
         async () => {
             Logger.info('Workspace folders changed event handler');
             const skillFolders = await findSkillFoldersInWs();
-            await context.workspaceState.update(EXTENSION_STATE_KEY.WS_SKILLS, skillFolders);
+            void context.workspaceState.update(EXTENSION_STATE_KEY.WS_SKILLS, skillFolders);
             if (skillFolders.length === 1) {
                 setSkillContext();
                 // tslint:disable-next-line: no-unused-expression
@@ -176,9 +176,9 @@ function registerUrlHooks(context: vscode.ExtensionContext): void {
             if (uri.path === '/clone') {
                 const profiles = Utils.listExistingProfileNames();
                 if (!profiles) {
-                    await vscode.window.showInformationMessage("Before you can clone your skill, you'll need"
+                    void vscode.window.showInformationMessage("Before you can clone your skill, you'll need"
                     + " to login to your developer account in the extension.");
-                    await vscode.commands.executeCommand('ask.login', true);
+                    void vscode.commands.executeCommand('ask.login', true);
                     await authenticate(context, undefined, DEFAULT_PROFILE);
                 }
                 await hostedSkillsClone(uri, context);
@@ -231,7 +231,7 @@ function addStatusBarItems(context: vscode.ExtensionContext): void {
     context.subscriptions.push(currentProfileIcon);
 }
 
-async function checkIfUpdated(context: vscode.ExtensionContext): Promise<void> {
+function checkIfUpdated(context: vscode.ExtensionContext): void {
     Logger.debug(`Checking if extension version is latest`);
     const lastKnownVersion = context.globalState.get(EXTENSION_STATE_KEY.CURRENT_VERSION);
     const extVersion = vscode.extensions.getExtension(EXTENSION_ID)?.packageJSON.version;
@@ -242,7 +242,7 @@ async function checkIfUpdated(context: vscode.ExtensionContext): Promise<void> {
             Logger.info(msg);
             void vscode.window.showInformationMessage(msg);
         }
-        await context.globalState.update(EXTENSION_STATE_KEY.CURRENT_VERSION, extVersion);
+        void context.globalState.update(EXTENSION_STATE_KEY.CURRENT_VERSION, extVersion);
     }
 }
 
@@ -253,18 +253,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             EXTENSION_STATE_KEY.LOG_LEVEL, DEFAULT_LOG_LEVEL));
     Logger.info('Activating extension');
 
-    await checkIfUpdated(context);
+    checkIfUpdated(context);
     registerUrlHooks(context);
     // Register common components
     const profiles = Utils.listExistingProfileNames();
     if (!profiles) {
-        await context.globalState.update(EXTENSION_STATE_KEY.LWA_PROFILE, undefined);
-        await context.globalState.update(EXTENSION_STATE_KEY.CACHED_SKILLS, {});
+        void context.globalState.update(EXTENSION_STATE_KEY.LWA_PROFILE, undefined);
+        void context.globalState.update(EXTENSION_STATE_KEY.CACHED_SKILLS, {});
         Logger.debug('No profiles found in the extension.');
     } else {
         const currentProfile = Utils.getCachedProfile(context);
         if (currentProfile === undefined || !profiles.includes(currentProfile)) {
-            await context.globalState.update(EXTENSION_STATE_KEY.LWA_PROFILE, profiles[0]);
+            void context.globalState.update(EXTENSION_STATE_KEY.LWA_PROFILE, profiles[0]);
             clearCachedSkills(context);
         }
     }
@@ -283,8 +283,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     
     const seenNotification = context.globalState.get(SEEN_TELEMETRY_NOTIFICATION_MESSAGE_KEY);
     if(seenNotification === undefined) {
-        await vscode.window.showInformationMessage(TELEMETRY_NOTIFICATION_MESSAGE);
-        await context.globalState.update(SEEN_TELEMETRY_NOTIFICATION_MESSAGE_KEY, true);
+        void vscode.window.showInformationMessage(TELEMETRY_NOTIFICATION_MESSAGE);
+        void context.globalState.update(SEEN_TELEMETRY_NOTIFICATION_MESSAGE_KEY, true);
     }
 }
 

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -6,7 +6,7 @@ async function main() {
   try {
     // The folder containing the Extension Manifest package.json
     // Passed to `--extensionDevelopmentPath`
-    const extensionDevelopmentPath = path.resolve(__dirname, '../');
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../');
 
     // The path to the extension test runner script
     // Passed to --extensionTestsPath


### PR DESCRIPTION
*Issue #, if available:*
1. The current testRunner script is failing
2. There are lot lint issues need to be fixed, thus temporarily remove lint task in pretest.
3. Revert some await before Thenable return type



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
