### PR TITLE
Improve simulateSkillHelper file into three smaller helper files

### DIFF
--- a/src/askContainer/commands/simulateReplay.ts
+++ b/src/askContainer/commands/simulateReplay.ts
@@ -14,9 +14,8 @@ export class SimulateReplayCommand extends AbstractCommand<void> {
     async execute(context: CommandContext): Promise<void> {
         Logger.debug(`Calling method: ${this.commandName}`);
         try {
-            // eslint-disable-next-line @typescript-eslint/await-thenable
-            await this.simulateSkillWebview.showView();
-            this.simulateSkillWebview.replaySessionInSimulator();
+            this.simulateSkillWebview.showView();
+            void this.simulateSkillWebview.replaySessionInSimulator();
 
         } catch (err) {
             throw loggableAskError(`Cannot open test skill view`, err, true);

--- a/src/askContainer/commands/simulateSkill.ts
+++ b/src/askContainer/commands/simulateSkill.ts
@@ -14,8 +14,7 @@ export class SimulateSkillCommand extends AbstractCommand<void> {
     async execute(context: CommandContext): Promise<void> {
         Logger.debug(`Calling method: ${this.commandName}`);
         try {
-            // eslint-disable-next-line @typescript-eslint/await-thenable
-            await this.simulateSkillWebview.showView();
+            this.simulateSkillWebview.showView();
         } catch (err) {
             throw loggableAskError(`Cannot open test skill view`, err, true);
         }

--- a/src/askContainer/webViews/simulateSkillWebview.ts
+++ b/src/askContainer/webViews/simulateSkillWebview.ts
@@ -8,7 +8,7 @@ import { DEFAULT_PROFILE, ERRORS, SIMULATOR_MESSAGE_TYPE } from '../../constants
 import { loggableAskError } from '../../exceptions';
 import { IViewport } from "apl-suggester";
 import * as simulateMessageHelper from '../../utils/simulateMessageHelper';
-import * as simulateNonSkillHelper from '../../utils/simulateNonSkillHelper';
+import { getReplayList, getNewViewPortMessage } from '../../utils/simulateReplayHelper';
 
 export class SimulateSkillWebview extends AbstractWebView {
     private loader: ViewLoader;
@@ -28,7 +28,6 @@ export class SimulateSkillWebview extends AbstractWebView {
     getHtmlForView(): string {
         Logger.debug(`Calling method: ${this.viewId}.getHtmlForView`);
 
-        //const webview: vscode.Webview = this.getWebview() as vscode.Webview;
         const simulateCss: vscode.Uri = this.getWebview()?.asWebviewUri(
             vscode.Uri.file(
                 path.join(
@@ -96,7 +95,7 @@ export class SimulateSkillWebview extends AbstractWebView {
 
     async replaySessionInSimulator(): Promise<void> {
         Logger.debug(`Calling method: ${this.viewId}.replaySessionInSimulator`);
-        const returnMessage = await simulateNonSkillHelper.getReplayList();
+        const returnMessage = await getReplayList();
         if (returnMessage !== null) {
             await this.getWebview()?.postMessage(returnMessage);
         }
@@ -105,7 +104,7 @@ export class SimulateSkillWebview extends AbstractWebView {
     //Get the document/datasource/new_viewport to change the preview.
     async changeViewport(viewport: IViewport): Promise<void> {
         Logger.verbose(`Calling method: ${this.viewId}.changeViewport, args: `, viewport.toString());
-        const returnMessage = simulateNonSkillHelper.getNewViewPortMessage(viewport);
+        const returnMessage = getNewViewPortMessage(viewport);
         await this.getWebview()?.postMessage(returnMessage);
     }
 }

--- a/src/askContainer/webViews/simulateSkillWebview.ts
+++ b/src/askContainer/webViews/simulateSkillWebview.ts
@@ -28,21 +28,21 @@ export class SimulateSkillWebview extends AbstractWebView {
     getHtmlForView(): string {
         Logger.debug(`Calling method: ${this.viewId}.getHtmlForView`);
 
-        const simulateCss: vscode.Uri = this.getWebview()?.asWebviewUri(
+        const simulateCss: vscode.Uri = this.getWebview().asWebviewUri(
             vscode.Uri.file(
                 path.join(
                     this.extensionContext.extensionPath, 'media', 'simulate.css',
                 ),
             ));
 
-        const aplRenderUtils: vscode.Uri = this.getWebview()?.asWebviewUri(
+        const aplRenderUtils: vscode.Uri = this.getWebview().asWebviewUri(
             vscode.Uri.file(
                 path.join(
                     this.extensionContext.extensionPath, 'media/previewApl', 'aplRenderUtils.js',
                 ),
             ));
 
-        const customJavascript = this.getWebview()?.asWebviewUri(
+        const customJavascript = this.getWebview().asWebviewUri(
             vscode.Uri.file(
                 path.join(
                     this.context.extensionPath, "/node_modules/apl-viewhost-web/index.js"))).toString();
@@ -67,7 +67,7 @@ export class SimulateSkillWebview extends AbstractWebView {
 
         if (message.type === SIMULATOR_MESSAGE_TYPE.SKILL_STATUS) {
             const returnMessage: string | Record<string, any> = await simulateMessageHelper.handleSkillStatusMessageFromWebview(message, profile, skillId, this.extensionContext);
-            await this.getWebview()?.postMessage({
+            await this.getWebview().postMessage({
                 message: returnMessage,
                 type: SIMULATOR_MESSAGE_TYPE.SKILL_STATUS
             });
@@ -75,12 +75,12 @@ export class SimulateSkillWebview extends AbstractWebView {
         else if (message.type === SIMULATOR_MESSAGE_TYPE.LOCALE) {
             const returnMessage: void | Record<string, any> = await simulateMessageHelper.handleLocaleMessageFromWebview(message, profile, skillId, this.extensionContext);
             if (returnMessage !== null) {
-                await this.getWebview()?.postMessage(returnMessage);
+                await this.getWebview().postMessage(returnMessage);
             }
         }
         else if (message.type === SIMULATOR_MESSAGE_TYPE.UTTERANCE) {
             const returnMessage = await simulateMessageHelper.handleUtteranceMessageFromWebview(message, profile, skillId, this.extensionContext);
-            await this.getWebview()?.postMessage(returnMessage);
+            await this.getWebview().postMessage(returnMessage);
         }
         else if (message.type === SIMULATOR_MESSAGE_TYPE.EXPORT) {
             void simulateMessageHelper.handleExportMessageFromWebview(message, skillId, skillName, this.extensionContext);
@@ -97,7 +97,7 @@ export class SimulateSkillWebview extends AbstractWebView {
         Logger.debug(`Calling method: ${this.viewId}.replaySessionInSimulator`);
         const returnMessage = await getReplayList();
         if (returnMessage !== null) {
-            await this.getWebview()?.postMessage(returnMessage);
+            await this.getWebview().postMessage(returnMessage);
         }
     }
 
@@ -105,6 +105,6 @@ export class SimulateSkillWebview extends AbstractWebView {
     async changeViewport(viewport: IViewport): Promise<void> {
         Logger.verbose(`Calling method: ${this.viewId}.changeViewport, args: `, viewport.toString());
         const returnMessage = getNewViewPortMessage(viewport);
-        await this.getWebview()?.postMessage(returnMessage);
+        await this.getWebview().postMessage(returnMessage);
     }
 }

--- a/src/utils/simulateMessageHelper.ts
+++ b/src/utils/simulateMessageHelper.ts
@@ -4,10 +4,10 @@ import { loggableAskError } from '../exceptions';
 import { getAvailableLocales } from '../utils/skillHelper';
 import {
     SKILL_ACTION_URLS,
-    ERRORS,SIMULATOR_WEBVIEW_MESSAGES, SIMULATOR_MESSAGE_TYPE, EN_US_LOCALE
+    ERRORS, SIMULATOR_WEBVIEW_MESSAGES, SIMULATOR_MESSAGE_TYPE, EN_US_LOCALE
 } from '../constants';
 import * as simulateSkillHelper from '../utils/simulateSkillHelper';
-import * as simulateNonSkillHelper from '../utils/simulateNonSkillHelper';
+import { exportFileForReplay } from './simulateReplayHelper';
 
 export let currentLocale = EN_US_LOCALE;
 export let currentSkillId: string;
@@ -22,7 +22,7 @@ export let isSkillEnabled = false;
  */
 export async function handleSkillStatusMessageFromWebview(webviewMessage: Record<string, any>, profile: string, skillId: string,
     context: vscode.ExtensionContext): Promise<string> {
-    Logger.verbose(`Calling method: simulateSkillHelper.handleSkillStatusMessageFromWebview`);
+    Logger.verbose(`Calling method: simulateMessageHelper.handleSkillStatusMessageFromWebview`);
     if (webviewMessage.message === SIMULATOR_WEBVIEW_MESSAGES.ENABLE_SKILL) {
         await simulateSkillHelper.enableSkill(profile, skillId, context);
         isSkillEnabled = true;
@@ -56,7 +56,7 @@ export async function handleSkillStatusMessageFromWebview(webviewMessage: Record
  */
 export async function handleLocaleMessageFromWebview(webviewMessage: Record<string, any>, profile: string, skillId: string,
     context: vscode.ExtensionContext): Promise<void | Record<string, any>> {
-    Logger.verbose(`Calling method: simulateSkillHelper.handleLocaleMessageFromWebview`);
+    Logger.verbose(`Calling method: simulateMessageHelper.handleLocaleMessageFromWebview`);
     if (webviewMessage.message === SIMULATOR_WEBVIEW_MESSAGES.CHECK_AVAILABLE_LOCALES) {
         const availableLocales = await getAvailableLocales(profile, skillId, context);
         if (availableLocales.availableLocales.length < 1) {
@@ -86,7 +86,7 @@ export async function handleLocaleMessageFromWebview(webviewMessage: Record<stri
  */
 export async function handleUtteranceMessageFromWebview(webviewMessage: Record<string, any>, profile: string,
     skillId: string, context: vscode.ExtensionContext): Promise<void | Record<string, any>> {
-    Logger.verbose(`Calling method: simulateSkillHelper.handleUtteranceMessageFromWebview`);
+    Logger.verbose(`Calling method: simulateMessageHelper.handleUtteranceMessageFromWebview`);
     const userInput: string = webviewMessage.userInput;
     const skillLocale: string = webviewMessage.skillLocale;
     const sessionMode: boolean = webviewMessage.sessionMode;
@@ -112,8 +112,8 @@ export async function handleUtteranceMessageFromWebview(webviewMessage: Record<s
  */
 export async function handleExportMessageFromWebview(webviewMessage: Record<string, any>,
     skillId: string, skillName: string, context: vscode.ExtensionContext): Promise<void> {
-    Logger.verbose(`Calling method: simulateSkillHelper.handleExportMessageFromWebview`);
-    await simulateNonSkillHelper.exportFileForReplay(webviewMessage, skillId, skillName, context);
+    Logger.verbose(`Calling method: simulateMessageHelper.handleExportMessageFromWebview`);
+    await exportFileForReplay(webviewMessage, skillId, skillName, context);
 }
 
 /**
@@ -122,7 +122,7 @@ export async function handleExportMessageFromWebview(webviewMessage: Record<stri
  * @param skillId Alexa Skill ID
  */
 export function handleActionMessageFromWebview(webviewMessage: Record<string, string>, skillId: string): void {
-    Logger.verbose(`Calling method: simulateSkillHelper.handleActionMessageFromWebview`);
+    Logger.verbose(`Calling method: simulateMessageHelper.handleActionMessageFromWebview`);
     let locale = webviewMessage.locale ? webviewMessage.locale : 'en-US';
     locale = locale.replace('-', '_');
     const goToConsole = 'Go to Alexa Developer Console';

--- a/src/utils/simulateMessageHelper.ts
+++ b/src/utils/simulateMessageHelper.ts
@@ -1,0 +1,136 @@
+import * as vscode from 'vscode';
+import { Logger } from '../logger';
+import { loggableAskError } from '../exceptions';
+import { getAvailableLocales } from '../utils/skillHelper';
+import {
+    SKILL_ACTION_URLS,
+    ERRORS,SIMULATOR_WEBVIEW_MESSAGES, SIMULATOR_MESSAGE_TYPE, EN_US_LOCALE
+} from '../constants';
+import * as simulateSkillHelper from '../utils/simulateSkillHelper';
+import * as simulateNonSkillHelper from '../utils/simulateNonSkillHelper';
+
+export let currentLocale = EN_US_LOCALE;
+export let currentSkillId: string;
+export let isSkillEnabled = false;
+
+/**
+ * Handle message sent from Webview when skill status is changed or check skill status 
+ * @param webviewMessage message sent from Webview
+ * @param profile user profile
+ * @param skillId Alexa Skill ID
+ * @param context VSCode extension context
+ */
+export async function handleSkillStatusMessageFromWebview(webviewMessage: Record<string, any>, profile: string, skillId: string,
+    context: vscode.ExtensionContext): Promise<string> {
+    Logger.verbose(`Calling method: simulateSkillHelper.handleSkillStatusMessageFromWebview`);
+    if (webviewMessage.message === SIMULATOR_WEBVIEW_MESSAGES.ENABLE_SKILL) {
+        await simulateSkillHelper.enableSkill(profile, skillId, context);
+        isSkillEnabled = true;
+        return SIMULATOR_WEBVIEW_MESSAGES.ENABLED_SKILL;
+    }
+    else if (webviewMessage.message === SIMULATOR_WEBVIEW_MESSAGES.DISABLE_SKILL) {
+        const skillEnabled = await simulateSkillHelper.checkSkillStatus(profile, skillId, context);
+        if (skillEnabled) {
+            await simulateSkillHelper.disableSkill(profile, skillId, context);
+        }
+        isSkillEnabled = false;
+        return SIMULATOR_WEBVIEW_MESSAGES.DISABLED_SKILL;
+    }
+    else if (webviewMessage.message === SIMULATOR_WEBVIEW_MESSAGES.CHECK_SKILL_STATUS) {
+        currentSkillId = skillId;
+        const skillEnabled = await simulateSkillHelper.checkSkillStatus(profile, skillId, context);
+        isSkillEnabled = skillEnabled;
+        return (skillEnabled) ? SIMULATOR_WEBVIEW_MESSAGES.ENABLED_SKILL : SIMULATOR_WEBVIEW_MESSAGES.DISABLED_SKILL;
+    }
+    else {
+        throw loggableAskError(ERRORS.UNRECOGNIZED_MESSAGE_FROM_WEBVIEW);
+    }
+}
+
+/**
+ * Handle message sent from Webview to check locales 
+ * @param webviewMessage message sent from Webview
+ * @param profile user profile
+ * @param skillId Alexa Skill ID
+ * @param context VSCode extension context
+ */
+export async function handleLocaleMessageFromWebview(webviewMessage: Record<string, any>, profile: string, skillId: string,
+    context: vscode.ExtensionContext): Promise<void | Record<string, any>> {
+    Logger.verbose(`Calling method: simulateSkillHelper.handleLocaleMessageFromWebview`);
+    if (webviewMessage.message === SIMULATOR_WEBVIEW_MESSAGES.CHECK_AVAILABLE_LOCALES) {
+        const availableLocales = await getAvailableLocales(profile, skillId, context);
+        if (availableLocales.availableLocales.length < 1) {
+            Logger.error(`Cannot find locales in this skill: `, skillId);
+        }
+        currentLocale = (webviewMessage.currentLocale !== undefined) ? webviewMessage.currentLocale : availableLocales.availableLocales[0];
+        return ({
+            locale: availableLocales,
+            type: SIMULATOR_MESSAGE_TYPE.LOCALE
+        });
+    }
+    else if (webviewMessage.message === SIMULATOR_WEBVIEW_MESSAGES.UPDATE_LOCALE) {
+        currentLocale = webviewMessage.skillLocale;
+    }
+
+    else {
+        throw loggableAskError(ERRORS.UNRECOGNIZED_MESSAGE_FROM_WEBVIEW);
+    }
+}
+
+/**
+ * Handle message sent from Webview when user enters input into chat box
+ * @param webviewMessage message sent from Webview
+ * @param profile user profile
+ * @param skillId Alexa Skill ID
+ * @param context VSCode extension context
+ */
+export async function handleUtteranceMessageFromWebview(webviewMessage: Record<string, any>, profile: string,
+    skillId: string, context: vscode.ExtensionContext): Promise<void | Record<string, any>> {
+    Logger.verbose(`Calling method: simulateSkillHelper.handleUtteranceMessageFromWebview`);
+    const userInput: string = webviewMessage.userInput;
+    const skillLocale: string = webviewMessage.skillLocale;
+    const sessionMode: boolean = webviewMessage.sessionMode;
+    try {
+        const simulationResult = await simulateSkillHelper.getSimulationResponse(userInput, skillLocale, sessionMode, profile, skillId, context);
+        const returnMessage = simulateSkillHelper.formatAlexaResponse(simulationResult, skillId);
+
+        if (returnMessage.type !== SIMULATOR_MESSAGE_TYPE.UTTERANCE && returnMessage.type !== SIMULATOR_MESSAGE_TYPE.EXCEPTION) {
+            throw loggableAskError(ERRORS.UNRECOGNIZED_SIMULATION_RETURN_MESSAGE);
+        }
+        return returnMessage;
+    }
+    catch (err) {
+        throw loggableAskError(ERRORS.SIMULATION_REQUEST_FAIL, err, true);
+    }
+}
+
+/**
+ * Handle message sent from Webview when user click export button
+ * @param webviewMessage message sent from Webview
+ * @param skillId Alexa Skill ID
+ * @param skillName
+ */
+export async function handleExportMessageFromWebview(webviewMessage: Record<string, any>,
+    skillId: string, skillName: string, context: vscode.ExtensionContext): Promise<void> {
+    Logger.verbose(`Calling method: simulateSkillHelper.handleExportMessageFromWebview`);
+    await simulateNonSkillHelper.exportFileForReplay(webviewMessage, skillId, skillName, context);
+}
+
+/**
+ * Handle message sent from Webview when user click preview div
+ * @param webviewMessage message sent from Webview
+ * @param skillId Alexa Skill ID
+ */
+export function handleActionMessageFromWebview(webviewMessage: Record<string, string>, skillId: string): void {
+    Logger.verbose(`Calling method: simulateSkillHelper.handleActionMessageFromWebview`);
+    let locale = webviewMessage.locale ? webviewMessage.locale : 'en-US';
+    locale = locale.replace('-', '_');
+    const goToConsole = 'Go to Alexa Developer Console';
+    const link = SKILL_ACTION_URLS.SIMULATOR(skillId, locale);
+    void vscode.window.showInformationMessage('This extension does not support interacting with the Alexa Presentation Language. ', goToConsole)
+        .then(selection => {
+            if (selection === goToConsole) {
+                void vscode.env.openExternal(vscode.Uri.parse(link));
+            }
+        });
+}

--- a/src/utils/simulateNonSkillHelper.ts
+++ b/src/utils/simulateNonSkillHelper.ts
@@ -1,0 +1,117 @@
+import * as vscode from 'vscode';
+import { Logger } from '../logger';
+import { loggableAskError } from '../exceptions';
+import { ERRORS, SIMULATOR_MESSAGE_TYPE } from '../constants';
+import { IViewport } from "apl-suggester";
+import { DEFAULT_VIEWPORT_CHARACTERISTICS } from "../aplContainer/utils/viewportProfileHelper";
+import { getCurrentDate } from '../utils/dateHelper';
+import { getSkillFolderInWs } from './workspaceHelper';
+import { read, write } from '../runtime/lib/utils/jsonUtility';
+import * as simulateMessageHelper from '../utils/simulateMessageHelper';
+import * as simulateSkillHelper from '../utils/simulateSkillHelper';
+
+export let aplViewport = DEFAULT_VIEWPORT_CHARACTERISTICS;
+
+/**
+ * Choose replay file then replay conversation automatically.
+ */
+export async function getReplayList(): Promise<void | Record<string, any>> {
+    Logger.verbose(`Calling method: simulateSkillHelper.getReplayList`);
+
+    const selectFileDialog = await vscode.window.showOpenDialog({
+        "canSelectFiles": true,
+        "canSelectFolders": false,
+        "canSelectMany": false,
+        "filters": {
+            "Json": ["json"]
+        }
+    });
+    const filePath = selectFileDialog ? selectFileDialog[0].fsPath : '';
+    if (filePath === '') {
+        return;
+    }
+    let inputList = [];
+    try {
+        const jsonObject = read(filePath);
+        inputList = jsonObject.userInput;
+        const locale = jsonObject.locale;
+        if (simulateMessageHelper.isSkillEnabled === false) {
+            void vscode.window.showErrorMessage(ERRORS.REPLAY_FAILED_ENABLE);
+            return;
+        }
+        else if (locale !== simulateMessageHelper.currentLocale) {
+            void vscode.window.showErrorMessage(ERRORS.REPLAY_FAILED_LOCALE);
+            return;
+        }
+        else if (inputList.length <= 0) {
+            void vscode.window.showErrorMessage(ERRORS.REPLAY_FAILED);
+            return;
+        }
+    } catch (err) {
+        throw loggableAskError(ERRORS.OPEN_REPLAY_FILE_FAIL(filePath), err, true);
+    }
+
+    const returnMessage: Record<string, any> = ({
+        replay: inputList,
+        type: SIMULATOR_MESSAGE_TYPE.REPLAY
+    });
+    return returnMessage;
+}
+
+/**
+ * Export utterances of the current session for replay.
+ * @param webviewMessage message sent from Webview
+ * @param skillId Alexa Skill ID
+ */
+export async function exportFileForReplay(message: Record<string, any>, skillId: string, skillName: string, context: vscode.ExtensionContext): Promise<void> {
+    Logger.verbose(`Calling method: simulateSkillHelper.exportFileForReplay`);
+
+    if (message.exportUtterance === undefined || message.exportUtterance.length <= 0) {
+        void vscode.window.showWarningMessage(ERRORS.EXPORT_FAILED);
+        return;
+    }
+    const exportContent = {
+        skillId,
+        locale: message.skillLocale,
+        userInput: message.exportUtterance
+    }
+
+    const dateToday = getCurrentDate();
+    skillName = skillName.replace(' ', '');
+    const locale = simulateMessageHelper.currentLocale;
+    const skillLocale = locale.replace('-', '_').toLowerCase();
+    const skillFolder = getSkillFolderInWs(context)?.fsPath;
+    const fileName = vscode.Uri.file(skillFolder + '/' + skillName + '_' + skillLocale + '_' + dateToday);
+
+    const saveFileDialog = await vscode.window.showSaveDialog({
+        defaultUri: fileName,
+        filters: {
+            "Json": ["json"]
+        }
+    });
+
+    if (saveFileDialog === undefined) {
+        return;
+    }
+    const filePath = saveFileDialog.fsPath;
+    write(filePath, exportContent);
+
+    const saveFileMsg = 'Simulator success: The file was saved in ' + filePath;
+    void vscode.window.showInformationMessage(saveFileMsg);
+    return;
+}
+
+/**
+ * Renew the aplViewport and send to webview.
+ * @param new viewport
+ * @returns object containing viewport type and document.
+ */
+export function getNewViewPortMessage(viewport: IViewport): Record<string, any> {
+    aplViewport = viewport;
+    return {
+        newViewport: JSON.stringify(aplViewport),
+        documents: simulateSkillHelper.aplDocument,
+        dataSources: simulateSkillHelper.aplDataSource,
+        type: SIMULATOR_MESSAGE_TYPE.VIEWPORT
+    }
+}

--- a/src/utils/simulateSkillHelper.ts
+++ b/src/utils/simulateSkillHelper.ts
@@ -7,7 +7,7 @@ import { SmapiClientFactory, Utils } from '../runtime';
 import { Logger } from '../logger';
 import { loggableAskError } from '../exceptions';
 import * as retry from 'async-retry';
-import * as simulateNonSkillHelper from '../utils/simulateNonSkillHelper';
+import {aplViewport} from './simulateReplayHelper';
 import {
     SKILL, DEFAULT_SESSION_MODE, NEW_SESSION_MODE, ALEXA_RESPONSE_TYPES,
     ERRORS, SIMULATION_IN_PROGRESS, SIMULATOR_MESSAGE_TYPE, DEFAULT_PROFILE
@@ -101,7 +101,7 @@ export async function getSimulationResponse(userInput: string, skillLocale: stri
         randomize: false
     };
 
-    const SESSION_MODE = createNewSession? NEW_SESSION_MODE : DEFAULT_SESSION_MODE;
+    const SESSION_MODE = createNewSession ? NEW_SESSION_MODE : DEFAULT_SESSION_MODE;
 
     const payload: SimulationsApiRequest = {
         'input': { 'content': userInput },
@@ -183,7 +183,7 @@ export function formatAlexaResponse(simulationResult: Record<string, any> | Simu
         const invocationRequestBodies: Array<Record<string, any>> | undefined = [];
         const invocationResponseBodies: Array<Record<string, any>> | undefined = [];
         const invocationsArray = simulationResult.skillExecutionInfo?.invocations;
-        if (invocationsArray !==undefined) {
+        if (invocationsArray !== undefined) {
             for (const invocation of invocationsArray) {
                 if (invocation.invocationRequest?.body && invocation.invocationResponse?.body) {
                     invocationRequestBodies.push(invocation.invocationRequest?.body);
@@ -235,7 +235,7 @@ export function formatAlexaResponse(simulationResult: Record<string, any> | Simu
             alexaResponse: alexaResponseTextContents,
             documents: aplDocument,
             dataSources: aplDataSource,
-            viewport: JSON.stringify(simulateNonSkillHelper.aplViewport),
+            viewport: JSON.stringify(aplViewport),
             skillId,
             type: SIMULATOR_MESSAGE_TYPE.UTTERANCE
         });

--- a/src/utils/simulateSkillHelper.ts
+++ b/src/utils/simulateSkillHelper.ts
@@ -7,237 +7,15 @@ import { SmapiClientFactory, Utils } from '../runtime';
 import { Logger } from '../logger';
 import { loggableAskError } from '../exceptions';
 import * as retry from 'async-retry';
-import { getAvailableLocales } from '../utils/skillHelper';
+import * as simulateNonSkillHelper from '../utils/simulateNonSkillHelper';
 import {
-    SKILL, DEFAULT_SESSION_MODE, NEW_SESSION_MODE, ALEXA_RESPONSE_TYPES, SKILL_ACTION_URLS,
-    ERRORS, SIMULATION_IN_PROGRESS, SIMULATOR_WEBVIEW_MESSAGES, SIMULATOR_MESSAGE_TYPE, EN_US_LOCALE,
-    DEFAULT_PROFILE
+    SKILL, DEFAULT_SESSION_MODE, NEW_SESSION_MODE, ALEXA_RESPONSE_TYPES,
+    ERRORS, SIMULATION_IN_PROGRESS, SIMULATOR_MESSAGE_TYPE, DEFAULT_PROFILE
 } from '../constants';
-import { IViewport } from "apl-suggester";
-import { DEFAULT_VIEWPORT_CHARACTERISTICS } from "../aplContainer/utils/viewportProfileHelper";
-import { getCurrentDate } from '../utils/dateHelper';
-import R = require('ramda');
-import { getSkillFolderInWs } from './workspaceHelper';
-import { read, write } from '../runtime/lib/utils/jsonUtility';
-
-let aplDataSource: string | undefined;
-let aplDocument: string | undefined;
-let aplViewport = DEFAULT_VIEWPORT_CHARACTERISTICS;
-let currentLocale = EN_US_LOCALE;
-let currentSkillId: string;
-let isSkillEnabled: boolean = false;
-
-/**
- * Handle message sent from Webview when skill status is changed or check skill status 
- * @param webviewMessage message sent from Webview
- * @param profile user profile
- * @param skillId Alexa Skill ID
- * @param context VSCode extension context
- */
-export async function handleSkillStatusMessageFromWebview(webviewMessage: Record<string, any>, profile: string, skillId: string,
-    context: vscode.ExtensionContext): Promise<string | Record<string, any>> {
-    Logger.verbose(`Calling method: simulateSkillHelper.handleSkillStatusMessageFromWebview`);
-    if (webviewMessage.message === SIMULATOR_WEBVIEW_MESSAGES.ENABLE_SKILL) {
-        await enableSkill(profile, skillId, context);
-        isSkillEnabled = true;
-        return SIMULATOR_WEBVIEW_MESSAGES.ENABLED_SKILL;
-    }
-    else if (webviewMessage.message === SIMULATOR_WEBVIEW_MESSAGES.DISABLE_SKILL) {
-        const skillEnabled = await checkSkillStatus(profile, skillId, context);
-        if (skillEnabled) {
-            await disableSkill(profile, skillId, context);
-        }
-        isSkillEnabled = false;
-        return SIMULATOR_WEBVIEW_MESSAGES.DISABLED_SKILL;
-    }
-    else if (webviewMessage.message === SIMULATOR_WEBVIEW_MESSAGES.CHECK_SKILL_STATUS) {
-        currentSkillId = skillId;
-        const skillEnabled = await checkSkillStatus(profile, skillId, context);
-        isSkillEnabled = skillEnabled;
-        return (skillEnabled) ? SIMULATOR_WEBVIEW_MESSAGES.ENABLED_SKILL : SIMULATOR_WEBVIEW_MESSAGES.DISABLED_SKILL;
-    }
-    else {
-        throw loggableAskError(ERRORS.UNRECOGNIZED_MESSAGE_FROM_WEBVIEW);
-    }
-}
-
-/**
- * Handle message sent from Webview to check locales 
- * @param webviewMessage message sent from Webview
- * @param profile user profile
- * @param skillId Alexa Skill ID
- * @param context VSCode extension context
- */
-export async function handleLocaleMessageFromWebview(webviewMessage: Record<string, any>, profile: string, skillId: string,
-    context: vscode.ExtensionContext): Promise<void | Record<string, any>> {
-    Logger.verbose(`Calling method: simulateSkillHelper.handleLocaleMessageFromWebview`);
-    if (webviewMessage.message === SIMULATOR_WEBVIEW_MESSAGES.CHECK_AVAILABLE_LOCALES) {
-        const availableLocales = await getAvailableLocales(profile, skillId, context);
-        if(availableLocales.availableLocales.length < 1){
-            Logger.error(`Cannot find locales in this skill: `, skillId);
-        }
-        currentLocale = (webviewMessage.currentLocale !== undefined)? webviewMessage.currentLocale : availableLocales.availableLocales[0];
-        return ({
-            locale: availableLocales,
-            type: SIMULATOR_MESSAGE_TYPE.LOCALE
-        });
-    }
-    else if (webviewMessage.message === SIMULATOR_WEBVIEW_MESSAGES.UPDATE_LOCALE) {
-        currentLocale = webviewMessage.skillLocale;
-    }
-
-    else {
-        throw loggableAskError(ERRORS.UNRECOGNIZED_MESSAGE_FROM_WEBVIEW);
-    }
-}
-
-/**
- * Handle message sent from Webview when user enters input into chat box
- * @param webviewMessage message sent from Webview
- * @param profile user profile
- * @param skillId Alexa Skill ID
- * @param context VSCode extension context
- */
-export async function handleUtteranceMessageFromWebview(webviewMessage: Record<string, any>, profile: string,
-    skillId: string, context: vscode.ExtensionContext): Promise<void | Record<string, any>> {
-    Logger.verbose(`Calling method: simulateSkillHelper.handleUtteranceMessageFromWebview`);
-    const userInput: string = webviewMessage.userInput;
-    const skillLocale: string = webviewMessage.skillLocale;
-    const sessionMode: boolean = webviewMessage.sessionMode;
-    try {
-        const simulationResult = await getSimulationResponse(userInput, skillLocale, sessionMode, profile, skillId, context);
-        const returnMessage = formatAlexaResponse(simulationResult, skillId);
-
-        if (returnMessage.type !== SIMULATOR_MESSAGE_TYPE.UTTERANCE && returnMessage.type !== SIMULATOR_MESSAGE_TYPE.EXCEPTION) {
-            throw loggableAskError(ERRORS.UNRECOGNIZED_SIMULATION_RETURN_MESSAGE);
-        }
-        return returnMessage;
-    }
-    catch (err) {
-        throw loggableAskError(ERRORS.SIMULATION_REQUEST_FAIL, err, true);
-    }
-}
 
 
-/**
- * Handle message sent from Webview when user click export button
- * @param webviewMessage message sent from Webview
- * @param skillId Alexa Skill ID
- * @param skillName
- */
-export function handleExportMessageFromWebview(webviewMessage: Record<string, any>,
-    skillId: string, skillName: string, context: vscode.ExtensionContext): Promise<void | Record<string, any>> {
-    Logger.verbose(`Calling method: simulateSkillHelper.handleExportMessageFromWebview`);
-    return exportFileForReplay(webviewMessage, skillId, skillName, context);
-}
-
-/**
- * Handle message sent from Webview when user click preview div
- * @param webviewMessage message sent from Webview
- * @param skillId Alexa Skill ID
- */
-export function handleActionMessageFromWebview(webviewMessage: Record<string, any>, skillId: string) {
-    Logger.verbose(`Calling method: simulateSkillHelper.handleActionMessageFromWebview`);
-    let locale = webviewMessage.locale ? webviewMessage.locale : 'en-US';
-    locale = locale.replace('-', '_');
-    const goToConsole = 'Go to Alexa Developer Console';
-    const link = SKILL_ACTION_URLS.SIMULATOR(skillId, locale);
-    vscode.window.showInformationMessage('This extension does not support interacting with the Alexa Presentation Language. ', goToConsole)
-        .then(selection => {
-            if (selection === goToConsole) {
-                vscode.env.openExternal(vscode.Uri.parse(link));
-            }
-        });
-}
-
-/**
- * Choose replay file then replay conversation automatically.
- */
-export async function getReplayList(): Promise<void | Record<string, any>> {
-    Logger.verbose(`Calling method: simulateSkillHelper.getReplayList`);
-
-    const selectFileDialog = await vscode.window.showOpenDialog({
-        "canSelectFiles": true,
-        "canSelectFolders": false,
-        "canSelectMany": false,
-        "filters": {
-            "Json": ["json"]
-        }
-    });
-    const filePath = selectFileDialog ? selectFileDialog[0].fsPath : '';
-    if (filePath === '') {
-        return;
-    }
-    let inputList = [];
-    try {
-        const jsonObject = read(filePath);
-        inputList = jsonObject.userInput;
-        const locale = jsonObject.locale;
-        if (isSkillEnabled === false) {
-            void vscode.window.showErrorMessage(ERRORS.REPLAY_FAILED_ENABLE);
-            return;
-        }
-        else if (locale !== currentLocale) {
-            vscode.window.showErrorMessage(ERRORS.REPLAY_FAILED_LOCALE);
-            return;
-        }
-        else if (inputList.length <= 0) {
-            vscode.window.showErrorMessage(ERRORS.REPLAY_FAILED);
-            return;
-        }
-    } catch (err) {
-        throw loggableAskError(ERRORS.OPEN_REPLAY_FILE_FAIL(filePath), err, true);
-    }
-
-    const returnMessage: Record<string, any> = ({
-        replay: inputList,
-        type: SIMULATOR_MESSAGE_TYPE.REPLAY
-    });
-    return returnMessage;
-}
-
-/**
- * Export utterances of the current session for replay.
- * @param webviewMessage message sent from Webview
- * @param skillId Alexa Skill ID
- */
-export async function exportFileForReplay(message: Record<string, any>, skillId: string, skillName: string, context: vscode.ExtensionContext): Promise<void> {
-    Logger.verbose(`Calling method: simulateSkillHelper.exportFileForReplay`);
-
-    if (message.exportUtterance === undefined || message.exportUtterance.length <= 0) {
-        vscode.window.showWarningMessage(ERRORS.EXPORT_FAILED);
-        return;
-    }
-    const exportContent = {
-        skillId: skillId,
-        locale: message.skillLocale,
-        userInput: message.exportUtterance
-    }
-
-    const dateToday = getCurrentDate();
-    skillName = skillName.replace(' ', '');
-    const skillLocale = currentLocale.replace('-', '_').toLowerCase();
-    const skillFolder = getSkillFolderInWs(context)?.fsPath; 
-    const fileName = vscode.Uri.file(skillFolder + '/' + skillName + '_' + skillLocale + '_' + dateToday);
-
-    const saveFileDialog = await vscode.window.showSaveDialog({
-        defaultUri: fileName,
-        filters: {
-            "Json": ["json"]
-        }
-    });
-
-    if (saveFileDialog === undefined) {
-        return;
-    }
-    const filePath = saveFileDialog.fsPath;
-    write(filePath, exportContent);
-
-    const saveFileMsg = 'Simulator success: The file was saved in ' + filePath;
-    vscode.window.showInformationMessage(saveFileMsg);
-    return;
-}
-
+export let aplDataSource: string | undefined;
+export let aplDocument: string | undefined;
 
 /**
  * Calls SMAPI Skill Enablement API to enable skill in Development stage
@@ -290,12 +68,12 @@ export async function checkSkillStatus(profile: string, skillId: string, context
             .callGetSkillEnablementStatusV1(skillId, SKILL.STAGE.DEVELOPMENT);
     }
     catch (err) {
-        if(err.statusCode === 401) {
+        if (err.statusCode === 401) {
             const profile = Utils.getCachedProfile(context) ?? DEFAULT_PROFILE;
-            vscode.window.showErrorMessage(ERRORS.PROFILE_ERROR(profile));
+            void vscode.window.showErrorMessage(ERRORS.PROFILE_ERROR(profile));
         }
         else {
-            vscode.window.showInformationMessage("The skill is off. Set the skill stage to development.");
+            void vscode.window.showInformationMessage("The skill is off. Set the skill stage to development.");
         }
         Logger.error(err);
         return false;
@@ -323,7 +101,7 @@ export async function getSimulationResponse(userInput: string, skillLocale: stri
         randomize: false
     };
 
-    const SESSION_MODE = (createNewSession === true) ? NEW_SESSION_MODE : DEFAULT_SESSION_MODE;
+    const SESSION_MODE = createNewSession? NEW_SESSION_MODE : DEFAULT_SESSION_MODE;
 
     const payload: SimulationsApiRequest = {
         'input': { 'content': userInput },
@@ -340,10 +118,10 @@ export async function getSimulationResponse(userInput: string, skillLocale: stri
     } catch (err) {
         if (err.statusCode === 401) {
             const profile = Utils.getCachedProfile(context) ?? DEFAULT_PROFILE;
-            vscode.window.showErrorMessage(ERRORS.PROFILE_ERROR(profile));
+            void vscode.window.showErrorMessage(ERRORS.PROFILE_ERROR(profile));
         }
         else {
-            vscode.window.showErrorMessage(err.message);
+            void vscode.window.showErrorMessage(err.message);
         }
         Logger.error(err);
         return ({
@@ -354,7 +132,7 @@ export async function getSimulationResponse(userInput: string, skillLocale: stri
 
     const simulationId: string | undefined = simulationResponse.id;
 
-    if (typeof simulationId === 'string') {
+    if (simulationId !== undefined) {
         return retry(async (bail: (err: Error) => void, attempt: number): Promise<Record<string, any> | SimulationResult> => {
             Logger.verbose(`Retrying simulation request, attempt: ${attempt}`);
             const simulationResponseContent = await SmapiClientFactory.getInstance(profile, context)
@@ -365,7 +143,7 @@ export async function getSimulationResponse(userInput: string, skillLocale: stri
                 throw loggableAskError(SIMULATION_IN_PROGRESS);
             }
 
-            if (simulationResponseContent.status === SKILL.SIMULATION_STATUS.FAILURE) {
+            else if (simulationResponseContent.status === SKILL.SIMULATION_STATUS.FAILURE) {
                 const errorMessage: string | undefined = simulationResponseContent.result?.error?.message;
                 let response = '';
                 if (typeof errorMessage === 'string') {
@@ -405,7 +183,7 @@ export function formatAlexaResponse(simulationResult: Record<string, any> | Simu
         const invocationRequestBodies: Array<Record<string, any>> | undefined = [];
         const invocationResponseBodies: Array<Record<string, any>> | undefined = [];
         const invocationsArray = simulationResult.skillExecutionInfo?.invocations;
-        if (invocationsArray) {
+        if (invocationsArray !==undefined) {
             for (const invocation of invocationsArray) {
                 if (invocation.invocationRequest?.body && invocation.invocationResponse?.body) {
                     invocationRequestBodies.push(invocation.invocationRequest?.body);
@@ -437,7 +215,7 @@ export function formatAlexaResponse(simulationResult: Record<string, any> | Simu
         let aplDataSourceTmp: string | undefined;
         let aplDocumentTmp: string | undefined;
         for (const responseBody of invocationResponseBodies) {
-            let directives = responseBody.response?.directives;
+            const directives = responseBody.response?.directives;
             if (directives != null) {
                 for (const directive of directives) {
                     if (directive.type === 'Alexa.Presentation.APL.RenderDocument') {
@@ -453,29 +231,17 @@ export function formatAlexaResponse(simulationResult: Record<string, any> | Simu
         return ({
             invocationRequests: invocationRequestBodies,
             invocationResponses: invocationResponseBodies,
-            alexaExecutionInfo: alexaExecutionInfo,
+            alexaExecutionInfo,
             alexaResponse: alexaResponseTextContents,
             documents: aplDocument,
             dataSources: aplDataSource,
-            viewport: JSON.stringify(aplViewport),
-            skillId: skillId,
+            viewport: JSON.stringify(simulateNonSkillHelper.aplViewport),
+            skillId,
             type: SIMULATOR_MESSAGE_TYPE.UTTERANCE
         });
     }
 }
 
 
-/**
- * Renew the aplViewport and send to webview.
- * @param new viewport
- * @returns object containing viewport type and document.
- */
-export function getNewViewPortMessage(viewport: IViewport): Record<string, any> {
-    aplViewport = viewport;
-    return {
-        newViewport: JSON.stringify(aplViewport),
-        documents: aplDocument,
-        dataSources: aplDataSource,
-        type: SIMULATOR_MESSAGE_TYPE.VIEWPORT
-    }
-}
+
+


### PR DESCRIPTION
*Issue #, if available:* 
With the growing features, the `simulatSkillHelper` file is getting larger, which will be difficult to maintain and do unit test.

*Description of changes:*
This PR separates the `simulateSkillHelper` file into three smaller files -`simulateSkillHelper`,`simulateNonSkillHelper` and `simulateMessageHelper`, which would be more clear than before.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
