### PR TITLE
fix: missing git execution current working directory

### DIFF
--- a/src/utils/gitHelper.ts
+++ b/src/utils/gitHelper.ts
@@ -130,7 +130,7 @@ export class GitInTerminalHelper {
             stdio: [null, showOutput === true ? 1 : null, showStdErr === true ? 2 : null],
             windowsHide: this.logLevel === LogLevel.verbose,
         };
-        if (workingDir === true) {
+        if (workingDir !== undefined) {
             execOptions.cwd = options.workingDir;
         }
         if (showCommand === true) {


### PR DESCRIPTION
*Issue*

Failed to assign git execution current working directory, which causes skill clone failing.

*Test*

Test skill creation/ skill clone and skill development.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
