### PR TITLE
Fix AplRenderUtils, to use all parameters in APL document during APL preview

### DIFF
--- a/media/previewApl/aplRenderUtils.js
+++ b/media/previewApl/aplRenderUtils.js
@@ -68,14 +68,15 @@ function createContent(apl, datasources) {
             jsonDoc.mainTemplate.parameters.length > 0
         ) {
             const parsedData = JSON.parse(data);
-            const name = jsonDoc.mainTemplate.parameters[0];
-            if (typeof name === "string") {
-                if (name === "payload") {
-                    content.addData(name, data);
-                } else if (parsedData[name]) {
-                    content.addData(name, JSON.stringify(parsedData[name]));
+            jsonDoc.mainTemplate.parameters.forEach((name) => {
+                if (typeof name === "string") {
+                    if (name === "payload") {
+                        content.addData(name, data);
+                    } else if (parsedData[name]) {
+                        content.addData(name, JSON.stringify(parsedData[name]));
+                    }
                 }
-            }
+            });
         }
     }
     return content;


### PR DESCRIPTION
## Description

APL 1.3 and above allows parameters to use key names other than `payload` as mentioned in the `About binding a data source to payload or other parameters` section [here](https://developer.amazon.com/en-US/docs/alexa/alexa-presentation-language/apl-data-source.html#bind-the-data-source-to-the-document). When using a document that has custom named parameters, the APL previewer doesn't render the doc because it is only using the first parameter. This PR fixes that, by taking all parameters into consideration.

## Testing

### APL Doc used (with multiple parameters)

*document.json*

```json
{
    "type": "APL",
    "version": "1.3",
    "settings": {},
    "theme": "dark",
    "import": [
        {
            "name": "alexa-layouts",
            "version": "1.1.0"
        }
    ],
    "resources": [],
    "styles": {
        "bigText": {
            "values": [
                {
                    "fontSize": "72dp",
                    "textAlign": "center"
                }
            ]
        }
    },
    "onMount": [],
    "graphics": {},
    "commands": {},
    "layouts": {},
    "mainTemplate": {
        "parameters": [
            "text",
            "assets"
        ],
        "items": [
            {
                "type": "Container",
                "when": "${@viewportProfile != @hubRoundSmall}",
                "items": [
                    {
                        "type": "Text",
                        "paddingTop": "12dp",
                        "paddingBottom": "12dp",
                        "text": "${text.start}",
                        "style": "bigText"
                    },
                    {
                        "type": "Text",
                        "text": "${text.middle}",
                        "style": "bigText"
                    },
                    {
                        "type": "Text",
                        "text": "${text.end}",
                        "style": "bigText"
                    },
                    {
                        "type": "Container",
                        "items": [
                            {
                                "type": "AlexaImage",
                                "alignSelf": "center",
                                "imageSource": "${assets.cake}",
                                "imageRoundedCorner": false,
                                "imageScale": "best-fill",
                                "imageHeight": "40vh",
                                "imageAspectRatio": "square",
                                "imageBlurredBackground": false
                            }
                        ]
                    }
                ],
                "height": "100%",
                "width": "100%"
            },
            {
                "type": "Container",
                "when": "${@viewportProfile == @hubRoundSmall}",
                "items": [
                    {
                        "type": "Text",
                        "paddingTop": "75dp",
                        "text": "${text.start}",
                        "style": "bigText"
                    },
                    {
                        "type": "Text",
                        "text": "${text.middle}",
                        "style": "bigText"
                    },
                    {
                        "type": "Text",
                        "text": "${text.end}",
                        "style": "bigText"
                    }
                ],
                "height": "100%",
                "width": "100%"
            }
        ]
    }
}
```

*datasources/default.json*

```json
{
    "text": {
        "start": "Welcome",
        "middle": "to",
        "end": "Cake Time!"
    },
    "assets": {
        "cake": "https://github.com/alexa/skill-sample-nodejs-first-apl-skill/blob/master/modules/assets/alexaCake_960x960.png?raw=true"
    }
}
```

### Before change

![Screen Shot 2020-11-24 at 1 59 29 PM](https://user-images.githubusercontent.com/25237515/100157063-cdd4a200-2e5e-11eb-887f-b6b36426b352.png)

### After change

![Screen Shot 2020-11-24 at 2 02 22 PM](https://user-images.githubusercontent.com/25237515/100157075-d4631980-2e5e-11eb-9e68-179730b00700.png)




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
