### PR TITLE
Add github actions to run extension tests on PRs/ pushes

### DIFF
--- a/.github/workflows/extensionTests.yml
+++ b/.github/workflows/extensionTests.yml
@@ -1,0 +1,34 @@
+# This is a workflow to run extension tests
+name: Extension tests
+
+# Controls when the action will run. 
+on:
+  push:
+    branches:
+      - development
+      - master
+  pull_request:
+    branches:
+      - development
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Install dependencies
+      run: npm install
+    - name: Run extension tests in linux
+      run: xvfb-run -a npm test
+      if: runner.os == 'Linux'
+    - name: Run extension tests
+      run: npm test
+      if: runner.os != 'Linux'

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -4,6 +4,8 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 import { EXTENSION_PUBLISHER, EXTENSION_FULL_NAME } from "../src/constants";
 import { ext } from "../src/extensionGlobals";
+import * as sinon from "sinon";
+import * as s3ScriptChecker from "../src/utils/s3ScriptChecker";
 
 const extensionId = `${EXTENSION_PUBLISHER}.${EXTENSION_FULL_NAME}`;
 
@@ -18,6 +20,7 @@ describe("Alexa Skill Kit Extension", () => {
     it("should activate", async () => {
         extension = vscode.extensions.getExtension(extensionId);
         if (extension !== undefined) {
+            sinon.stub(s3ScriptChecker, 'checkAllSkillS3Scripts');
             await extension.activate();
             assert.ok(extension.isActive);
         } else {

--- a/test/index.ts
+++ b/test/index.ts
@@ -47,7 +47,7 @@ function setupCoverage() {
 const mocha = new Mocha({
     ui: "bdd",
     color: true,
-    timeout: 10 * 1000,
+    timeout: 20 * 1000, // for windows extension activation test
 });
 
 export async function run(): Promise<void> {

--- a/test/runtime/utils/profileHelper.test.ts
+++ b/test/runtime/utils/profileHelper.test.ts
@@ -3,6 +3,7 @@ import * as sinon from "sinon";
 import * as fs from "fs";
 import * as os from "os";
 import * as jsonfile from "jsonfile";
+import * as path from "path";
 
 import { listExistingProfileNames, createConfigFileIfNotExists } from "../../../src/runtime/lib/utils/profileHelper";
 import * as jsonUtility from "../../../src/runtime/lib/utils/jsonUtility";
@@ -53,28 +54,28 @@ describe("ProfileHelper tests", () => {
             const writeFileSpy = sandbox.stub(jsonfile, "writeFileSync");
 
             createConfigFileIfNotExists();
-            assert.ok(mkdirSpy.calledOnceWith("foo/.ask"));
-            assert.ok(writeFileSpy.calledOnceWith("foo/.ask/cli_config", { profiles: {} }, { spaces: 2, mode: '0600' }));
+            assert.ok(mkdirSpy.calledOnceWith(path.join("foo", ".ask")));
+            assert.ok(writeFileSpy.calledOnceWith(path.join("foo", ".ask", "cli_config"), { profiles: {} }, { spaces: 2, mode: '0600' }));
         });
 
         it("Should only create config file when only folder is exist", () => {
             sandbox.stub(os, "homedir").returns("foo");
             const existsSyncStub = sandbox.stub(fs, "existsSync");
-            existsSyncStub.withArgs("foo/.ask").returns(true);
-            existsSyncStub.withArgs("foo/.ask/cli_config").returns(false);
+            existsSyncStub.withArgs(path.join("foo", ".ask")).returns(true);
+            existsSyncStub.withArgs(path.join("foo", ".ask", "cli_config")).returns(false);
             const mkdirSpy = sandbox.stub(fs, "mkdirSync");
             const writeFileSpy = sandbox.stub(jsonfile, "writeFileSync");
 
             createConfigFileIfNotExists();
             assert.ok(mkdirSpy.notCalled);
-            assert.ok(writeFileSpy.calledOnceWith("foo/.ask/cli_config", { profiles: {} }, { spaces: 2, mode: '0600' }));
+            assert.ok(writeFileSpy.calledOnceWith(path.join("foo", ".ask", "cli_config"), { profiles: {} }, { spaces: 2, mode: '0600' }));
         });
 
         it("Do nothing when both folder and config file exist", () => {
             sandbox.stub(os, "homedir").returns("foo");
             const existsSyncStub = sandbox.stub(fs, "existsSync");
-            existsSyncStub.withArgs("foo/.ask").returns(true);
-            existsSyncStub.withArgs("foo/.ask/cli_config").returns(true);
+            existsSyncStub.withArgs(path.join("foo", ".ask")).returns(true);
+            existsSyncStub.withArgs(path.join("foo", ".ask", "cli_config")).returns(true);
             const mkdirSpy = sandbox.stub(fs, "mkdirSync");
             const writeFileSpy = sandbox.stub(jsonfile, "writeFileSync");
 


### PR DESCRIPTION
### Description of changes

This PR adds the extension tests as github actions, following the vscode extension CI docs : https://code.visualstudio.com/api/working-with-extensions/continuous-integration#github-actions. The PR also fixes some extension source that used to fail on windows machines.

### Testing

Created a PR on `development` branch in own fork here, to run the github actions : https://github.com/nikhilym/ask-toolkit-for-vscode/pull/1 . You can check the github actions run history here : https://github.com/nikhilym/ask-toolkit-for-vscode/actions/runs/384406638


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
