### PR TITLE
fix: add condition to apl renderer content for invalid parameter names

### DIFF
--- a/media/previewApl/aplRenderUtils.js
+++ b/media/previewApl/aplRenderUtils.js
@@ -74,6 +74,8 @@ function createContent(apl, datasources) {
                         content.addData(name, data);
                     } else if (parsedData[name]) {
                         content.addData(name, JSON.stringify(parsedData[name]));
+                    } else {
+                        content.addData(name, '{}');
                     }
                 }
             });


### PR DESCRIPTION
### Description

This commit adds the else condition to the apl content builder, for parameter names that are missing in the datasources document. This is done w.r.t the changes suggested by APL team : https://github.com/alexa/ask-toolkit-for-vscode/pull/68#pullrequestreview-538039520 . @alexa/alexa-multimodal team / @renewu0707 can review the changes too.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
