### PR TITLE
fix: configure current working directory to skill code folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,7 +211,8 @@
                                 "^\"\\${workspaceFolder}/lambda/index.js\"",
                                 "--region",
                                 "${1|NA,EU,FE|}"
-                            ]
+                            ],
+                            "cwd": "^\"\\${workspaceFolder}/lambda\""
                         }
                     }
                 ]
@@ -243,7 +244,8 @@
                                 "--region",
                                 "${1|NA,EU,FE|}"
                             ],
-                            "console": "internalConsole"
+                            "console": "internalConsole",
+                            "cwd": "^\"\\${workspaceFolder}/lambda\""
                         }
                     }
                 ]


### PR DESCRIPTION
configure current working directory to skill code folder. Defaults to the lambda skill package structure.

*Issue #, if available:* https://github.com/alexa/alexa-skills-kit-sdk-for-python/issues/183

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
