### PR TITLE
feat: upgrade apl-suggester and apl-viewhost-web to version 1.5

### DIFF
--- a/media/previewApl/previewApl.html
+++ b/media/previewApl/previewApl.html
@@ -5,7 +5,7 @@
     content="default-src https: data:; img-src https: data:; script-src vscode-resource: https: data: 'unsafe-inline' 'unsafe-eval'; style-src vscode-resource: 'unsafe-inline';" />
     
     <title>APL Preview</title>
-    <script src="https://d2o906d8ln7ui1.cloudfront.net/apl-wasm-1.4.js"></script>
+    <script src="https://d2o906d8ln7ui1.cloudfront.net/apl-wasm-1.5.js"></script>
     <script>window.AplRenderer || document.write('<script src="${customJavascript}"><\\/script>')</script> 
     <script src="${aplRenderUtils}"></script>
     <script src="${javascript}"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1204,16 +1204,16 @@
             }
         },
         "apl-suggester": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/apl-suggester/-/apl-suggester-1.1.1.tgz",
-            "integrity": "sha512-ppu6KPXHd9Q1yjMOfwn54pTuTJUSN0KgAffSohJZN6XuKShHgMCeRIKpeNTFQ6QwswPI8cvsjaMAB6GrbD4/vw==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/apl-suggester/-/apl-suggester-1.5.0.tgz",
+            "integrity": "sha512-4SASYay1iN+FTN5wYQPSAHe1zJpPpYpoaHkiQfG6QBVEh0ODIsBUXzxsaRp5sRDEoj65e3J/8rGp4BNDDYf9tQ==",
             "requires": {
                 "@types/chai": "3.5.x",
                 "@types/core-js": "2.5.x",
                 "@types/node": "12.0.x",
                 "@types/sinon": "2.2.x",
                 "ajv": "6.10.x",
-                "axios": "0.18.x",
+                "axios": ">=0.21.1",
                 "immutable": ">4.0.0-rc",
                 "jsdom-global": "3.0.x",
                 "ts-node": "3.3.x",
@@ -1229,15 +1229,6 @@
                     "version": "2.2.2",
                     "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-2.2.2.tgz",
                     "integrity": "sha1-qA2khougisysvOTTcnbzXhugpS8="
-                },
-                "axios": {
-                    "version": "0.18.1",
-                    "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
-                    "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
-                    "requires": {
-                        "follow-redirects": "1.5.10",
-                        "is-buffer": "^2.0.2"
-                    }
                 },
                 "ts-node": {
                     "version": "3.3.0",
@@ -1259,9 +1250,9 @@
             }
         },
         "apl-viewhost-web": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/apl-viewhost-web/-/apl-viewhost-web-1.4.0.tgz",
-            "integrity": "sha512-DbN4YDEqaTZBXgRfGoiEz0vedjVhwjcCoZ32EHmnDixa22C/053NoZLkoBcohQbBey8G/p3eYPIz2y5kE2RufA=="
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/apl-viewhost-web/-/apl-viewhost-web-1.5.0.tgz",
+            "integrity": "sha512-uzJCPslnwJlZ3F1R3oIV3f48G498+1cMl8NZq7bytD2kUHZhMpiI6jj2A5TwzeIlUF1JMvmqgtHc5gLDqyzLnw=="
         },
         "append-buffer": {
             "version": "1.0.2",
@@ -5321,14 +5312,6 @@
                 }
             }
         },
-        "follow-redirects": {
-            "version": "1.5.10",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-            "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-            "requires": {
-                "debug": "=3.1.0"
-            }
-        },
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -6833,7 +6816,8 @@
         "is-buffer": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-            "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+            "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+            "dev": true
         },
         "is-callable": {
             "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -320,8 +320,8 @@
     },
     "dependencies": {
         "adm-zip": "0.4.14",
-        "apl-suggester": "1.1.1",
-        "apl-viewhost-web": "1.4.0",
+        "apl-suggester": "^1.5.0",
+        "apl-viewhost-web": "^1.5.0",
         "ask-smapi-sdk": "^1.2.2",
         "async-retry": "^1.3.1",
         "axios": "^0.21.1",


### PR DESCRIPTION
Feature

- upgrade apl-suggester dependency from 1.1.1 to 1.5
- upgrade apl-viewhost-web dependency from 1.4.0 to 1.5
- update reference link of apl web view host from 1.4 to 1.5 in previewApl HTML

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
