### PR TITLE
fix: passing command line arguments to npm script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -263,8 +263,8 @@
         "pretest": "npm run compile",
         "test": "node ./out/test/runTest.js",
         "pre-release": "standard-version",
-        "package": "vsce package",
-        "publish": "vsce publish"
+        "package": "vsce package --out $npm_config_out",
+        "publish": "vsce publish --pat $npm_config_pat --packagePath $npm_config_packagePath"
     },
     "devDependencies": {
         "@commitlint/cli": "^11.0.0",


### PR DESCRIPTION

*Description of changes:*

To pass an argument from npm run script to vsce package. e.g. We can set the $npm_config_out configuration parameter to --out . An environment parameter that starts with npm_config_ will be interpreted as a configuration parameter (See doc (https://docs.npmjs.com/cli/v6/using-npm/config#environment-variables)). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
