### PR TITLE
fix: render apl response without speak tag in simulator. fixes #82

### DIFF
--- a/media/simulateSkill/simulateSkill.js
+++ b/media/simulateSkill/simulateSkill.js
@@ -475,10 +475,12 @@ async function handleAlexaResponse(message) {
     }
     else {
         message.alexaResponse.forEach(response => updateAlexaResponse(response));
-        //If message contains datasource and document, will show APL preview
-        if (message.viewport !== undefined && message.documents !== undefined) {
-            await updateAplViewPort(message.documents, message.dataSources, JSON.parse(message.viewport));
-        }
+        
+    }
+    // Response can have empty speech, but valid APL response to render
+    // If message contains datasource and document, will show APL preview
+    if (message.viewport !== undefined && message.documents !== undefined) {
+        await updateAplViewPort(message.documents, message.dataSources, JSON.parse(message.viewport));
     }
     extractSkillInfoData(message);
 }


### PR DESCRIPTION
**Description of changes:**

This PR fixes the issue of not rendering APL responses, in case there is an empty speak tag in Alexa response, but valid APL response. This fixes the issue mentioned in #82 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
