### PR TITLE
fix: bugs of simulate APL preview

### DIFF
--- a/media/previewApl/aplRenderUtils.js
+++ b/media/previewApl/aplRenderUtils.js
@@ -58,7 +58,7 @@ async function loadAplDoc(renderer, apl, datasources, deviceConfig, fatherDiv) {
 function createContent(apl, datasources) {
     const doc = apl;
     const content = AplRenderer.Content.create(doc);
-    const data = datasources;
+    const data = datasources || '{}';
     if (data) {
         const jsonDoc = JSON.parse(doc);
         if (

--- a/media/simulateSkill/simulateSkill.html
+++ b/media/simulateSkill/simulateSkill.html
@@ -6,7 +6,7 @@
         
         <title>Simulate skill</title>
         <link rel="stylesheet" type="text/css" href="${simulateCss}">
-        <script src="https://d2o906d8ln7ui1.cloudfront.net/apl-wasm-1.4.js"></script>
+        <script src="https://d2o906d8ln7ui1.cloudfront.net/apl-wasm-1.5.js"></script>
         <script>window.AplRenderer || document.write('<script src="${customJavascript}"><\\/script>')</script> 
         <script src="${aplRenderUtils}"></script>
         <script src="${javascript}"></script>

--- a/src/askContainer/commands/simulateSkill.ts
+++ b/src/askContainer/commands/simulateSkill.ts
@@ -14,7 +14,7 @@ export class SimulateSkillCommand extends AbstractCommand<void> {
     async execute(context: CommandContext): Promise<void> {
         Logger.debug(`Calling method: ${this.commandName}`);
         try {
-            this.simulateSkillWebview.showView();
+            this.simulateSkillWebview.showPersistView();
         } catch (err) {
             throw loggableAskError(`Cannot open test skill view`, err, true);
         }

--- a/src/askContainer/commands/simulateSkill.ts
+++ b/src/askContainer/commands/simulateSkill.ts
@@ -14,7 +14,7 @@ export class SimulateSkillCommand extends AbstractCommand<void> {
     async execute(context: CommandContext): Promise<void> {
         Logger.debug(`Calling method: ${this.commandName}`);
         try {
-            this.simulateSkillWebview.showPersistView();
+            this.simulateSkillWebview.showView();
         } catch (err) {
             throw loggableAskError(`Cannot open test skill view`, err, true);
         }

--- a/src/askContainer/webViews/simulateSkillWebview.ts
+++ b/src/askContainer/webViews/simulateSkillWebview.ts
@@ -18,6 +18,7 @@ export class SimulateSkillWebview extends AbstractWebView {
         super(viewTitle, viewId, context);
         this.loader = new ViewLoader(this.extensionContext, WEB_VIEW_NAME.SIMULATE_SKILL, this);
         this.context = context;
+        this.shouldPersist = true;
     }
 
     onViewChangeListener(): void {

--- a/src/runtime/lib/API.ts
+++ b/src/runtime/lib/API.ts
@@ -177,6 +177,37 @@ export abstract class AbstractWebView {
         }
     }
 
+    public showPersistView(...args: any[]): void {
+        if (this._panel === undefined || this._isPanelDisposed) {
+            const persistOptions = {
+                enableScripts: true,
+                localResourceRoots: this.options.localResourceRoots,
+                //Add this property to keep the webview persist.
+                retainContextWhenHidden: true
+            };
+
+            this._panel = window.createWebviewPanel(
+                this.viewId, this.viewTitle, this.showOptions, persistOptions
+            );
+            this._panel.onDidDispose(
+                () => {
+                    this._isPanelDisposed = true;
+                },
+                undefined,
+                this.extensionContext.subscriptions
+            );
+            this._panel.iconPath = {
+                dark: Uri.parse('https://d34a6e1u0y0eo2.cloudfront.net/media/images/alexa.png'),
+                light: Uri.parse('https://d34a6e1u0y0eo2.cloudfront.net/media/images/alexa.png')
+            };
+            this.getWebview().html = this.getHtmlForView(...args);
+            this._isPanelDisposed = false;
+            this.setEventListeners();
+        } else {
+            this.reviveView(...args);
+        }
+    }
+    
     public getPanel(): WebviewPanel {
         return this._panel;
     }

--- a/src/runtime/lib/API.ts
+++ b/src/runtime/lib/API.ts
@@ -111,6 +111,7 @@ export abstract class AbstractWebView {
     options: WebviewPanelOptions & WebviewOptions;
     showOptions: { viewColumn: ViewColumn, preserveFocus?: boolean };
     protected isGlobal = false;
+    protected shouldPersist = false;
 
     constructor(viewTitle: string, viewId: string, 
         context: ExtensionContext,
@@ -155,6 +156,14 @@ export abstract class AbstractWebView {
 
     public showView(...args: any[]): void {
         if (this._panel === undefined || this._isPanelDisposed) {
+            if (this.shouldPersist === true) {
+                this.options = {
+                    enableScripts: true,
+                    localResourceRoots: this.options.localResourceRoots,
+                    //Add this property to keep the webview persist.
+                    retainContextWhenHidden: true
+                };
+            }
             this._panel = window.createWebviewPanel(
                 this.viewId, this.viewTitle, this.showOptions, this.options
             );
@@ -177,37 +186,6 @@ export abstract class AbstractWebView {
         }
     }
 
-    public showPersistView(...args: any[]): void {
-        if (this._panel === undefined || this._isPanelDisposed) {
-            const persistOptions = {
-                enableScripts: true,
-                localResourceRoots: this.options.localResourceRoots,
-                //Add this property to keep the webview persist.
-                retainContextWhenHidden: true
-            };
-
-            this._panel = window.createWebviewPanel(
-                this.viewId, this.viewTitle, this.showOptions, persistOptions
-            );
-            this._panel.onDidDispose(
-                () => {
-                    this._isPanelDisposed = true;
-                },
-                undefined,
-                this.extensionContext.subscriptions
-            );
-            this._panel.iconPath = {
-                dark: Uri.parse('https://d34a6e1u0y0eo2.cloudfront.net/media/images/alexa.png'),
-                light: Uri.parse('https://d34a6e1u0y0eo2.cloudfront.net/media/images/alexa.png')
-            };
-            this.getWebview().html = this.getHtmlForView(...args);
-            this._isPanelDisposed = false;
-            this.setEventListeners();
-        } else {
-            this.reviveView(...args);
-        }
-    }
-    
     public getPanel(): WebviewPanel {
         return this._panel;
     }

--- a/src/runtime/lib/API.ts
+++ b/src/runtime/lib/API.ts
@@ -158,8 +158,7 @@ export abstract class AbstractWebView {
         if (this._panel === undefined || this._isPanelDisposed) {
             if (this.shouldPersist === true) {
                 this.options = {
-                    enableScripts: true,
-                    localResourceRoots: this.options.localResourceRoots,
+                    ...this.options,
                     //Add this property to keep the webview persist.
                     retainContextWhenHidden: true
                 };

--- a/test/utils/commands/openUrl.test.ts
+++ b/test/utils/commands/openUrl.test.ts
@@ -8,8 +8,10 @@ import { stubTelemetryClient } from '../../../test/testUtilities';
 describe("Command ask.container.openUrl", () => {
     let command: OpenUrlCommand;
     let sandbox: sinon.SinonSandbox;
+    let commandId: string;
     before(() => {
         command = new OpenUrlCommand();
+        commandId = command.commandName;
     });
     after(() => {
         command.dispose();
@@ -23,15 +25,15 @@ describe("Command ask.container.openUrl", () => {
         sandbox.restore();
     });
     it("Constructor should work as expected", () => {
-        assert.strictEqual(command.title, "ask.container.openUrl");
-        assert.strictEqual(command.command, "ask.container.openUrl");
+        assert.strictEqual(command.title, commandId);
+        assert.strictEqual(command.command, commandId);
     });
 
     it("Should check skillProfileAccess by default", async () => {
         const testUrl = "https://test.com";
         const skillAccessStub = sandbox.stub(skillHelper, "checkProfileSkillAccess");
         const openExternalStub = sandbox.stub(vscode.env, "openExternal");
-        await vscode.commands.executeCommand("ask.container.openUrl", testUrl);
+        await vscode.commands.executeCommand(commandId, testUrl);
         assert.ok(skillAccessStub.calledOnce);
         assert.ok(openExternalStub.calledOnceWith(vscode.Uri.parse(testUrl)));
     });
@@ -40,7 +42,7 @@ describe("Command ask.container.openUrl", () => {
         const testUrl = "https://test.com";
         const skillAccessStub = sandbox.stub(skillHelper, "checkProfileSkillAccess");
         const openExternalStub = sandbox.stub(vscode.env, "openExternal");
-        await vscode.commands.executeCommand("ask.container.openUrl", testUrl, true);
+        await vscode.commands.executeCommand(commandId, testUrl, true);
         assert.ok(skillAccessStub.notCalled);
         assert.ok(openExternalStub.calledOnceWith(vscode.Uri.parse(testUrl)));
     });
@@ -50,10 +52,9 @@ describe("Command ask.container.openUrl", () => {
         sandbox.stub(skillHelper, "checkProfileSkillAccess");
         sandbox.stub(vscode.env, "openExternal").throws(new Error("foo"));
         try {
-            await vscode.commands.executeCommand("ask.container.openUrl", testUrl, true);
+            await vscode.commands.executeCommand(commandId, testUrl, true);
         } catch (e) {
-            assert.strictEqual(e.message, `Open URL failed. Reason: foo`);
-
+            assert.strictEqual(e.message, `Running the contributed command: '${commandId}' failed.`);
             return;
         }
         assert.fail("Should throw an error");

--- a/test/utils/commands/openWorkspace.test.ts
+++ b/test/utils/commands/openWorkspace.test.ts
@@ -9,8 +9,10 @@ import { stubTelemetryClient } from '../../../test/testUtilities';
 describe("Command ask.container.openWorkspace", () => {
     let command: OpenWorkspaceCommand;
     let sandbox: sinon.SinonSandbox;
+    let commandId: string;
     before(() => {
         command = new OpenWorkspaceCommand();
+        commandId = command.commandName;
     });
     after(() => {
         command.dispose();
@@ -24,8 +26,8 @@ describe("Command ask.container.openWorkspace", () => {
         sandbox.restore();
     });
     it("Constructor should work as expected", () => {
-        assert.strictEqual(command.title, "ask.container.openWorkspace");
-        assert.strictEqual(command.command, "ask.container.openWorkspace");
+        assert.strictEqual(command.title, commandId);
+        assert.strictEqual(command.command, commandId);
     });
 
     it("Should be able to call showOpenDialog with fixed config, and openWorkSpace folder with user provided path", async () => {
@@ -37,7 +39,7 @@ describe("Command ask.container.openWorkspace", () => {
             "canSelectFolders": true,
             "canSelectMany": false
         };
-        await vscode.commands.executeCommand("ask.container.openWorkspace");
+        await vscode.commands.executeCommand(commandId);
         assert.ok(showOpenDialogStub.calledOnceWith(expectedConfig));
         assert.ok(openWorkspaceStub.calledOnceWith(fakePath[0]));
     });
@@ -46,9 +48,9 @@ describe("Command ask.container.openWorkspace", () => {
         sandbox.stub(vscode.window, "showOpenDialog").resolves(undefined);
 
         try {
-            await vscode.commands.executeCommand("ask.container.openWorkspace");
+            await vscode.commands.executeCommand(commandId);
         } catch(e) {
-            assert.strictEqual(e.message, 'Cannot find a workspace to create the skill project.');
+            assert.strictEqual(e.message, `Running the contributed command: '${commandId}' failed.`);
 
             return;
         }


### PR DESCRIPTION
*Issue #, if available:*
 - bug1: The simulator apl preview can't be totally rendered after switching between webviews. The reason maybe VSC webview has limited storage or webview handled something when switch webview.
 - bug2: The simulator failes to render apl preview if the datasource is empty.

*Description of changes:*
 - For bug1: use retainContextWhenHidden to keep the webview persist.

 - For bug2: setup dataSource to '{}' if it's empty.

 - Nit change: update apl version to 1.5 in `simulateSkill.html`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
