### PR TITLE
fix: filter unused APL sample templates

### DIFF
--- a/src/aplContainer/commands/createAplDocumentFromSample.ts
+++ b/src/aplContainer/commands/createAplDocumentFromSample.ts
@@ -142,6 +142,7 @@ export class CreateAplDocumentFromSampleCommand extends AbstractCommand<void> {
                         id: k
                     } as SampleTemplateQuickPickItem)
             )
+            .filter((item) => !!item.label)
             .valueSeq()
             .toArray();
     }


### PR DESCRIPTION
*Description of changes:*

Some unused APL sample templates will break create APL template from sample template dropdown. This filter removed unused sample templates to fix the issue. The unused APL templates are for testing purpose

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
