### PR TITLE
Fix the unit tests failing in the extension due to VSCode 1.53 version

### DIFF
--- a/test/utils/commands/openUrl.test.ts
+++ b/test/utils/commands/openUrl.test.ts
@@ -8,8 +8,10 @@ import { stubTelemetryClient } from '../../../test/testUtilities';
 describe("Command ask.container.openUrl", () => {
     let command: OpenUrlCommand;
     let sandbox: sinon.SinonSandbox;
+    let commandId: string;
     before(() => {
         command = new OpenUrlCommand();
+        commandId = command.commandName;
     });
     after(() => {
         command.dispose();
@@ -23,15 +25,15 @@ describe("Command ask.container.openUrl", () => {
         sandbox.restore();
     });
     it("Constructor should work as expected", () => {
-        assert.strictEqual(command.title, "ask.container.openUrl");
-        assert.strictEqual(command.command, "ask.container.openUrl");
+        assert.strictEqual(command.title, commandId);
+        assert.strictEqual(command.command, commandId);
     });
 
     it("Should check skillProfileAccess by default", async () => {
         const testUrl = "https://test.com";
         const skillAccessStub = sandbox.stub(skillHelper, "checkProfileSkillAccess");
         const openExternalStub = sandbox.stub(vscode.env, "openExternal");
-        await vscode.commands.executeCommand("ask.container.openUrl", testUrl);
+        await vscode.commands.executeCommand(commandId, testUrl);
         assert.ok(skillAccessStub.calledOnce);
         assert.ok(openExternalStub.calledOnceWith(vscode.Uri.parse(testUrl)));
     });
@@ -40,7 +42,7 @@ describe("Command ask.container.openUrl", () => {
         const testUrl = "https://test.com";
         const skillAccessStub = sandbox.stub(skillHelper, "checkProfileSkillAccess");
         const openExternalStub = sandbox.stub(vscode.env, "openExternal");
-        await vscode.commands.executeCommand("ask.container.openUrl", testUrl, true);
+        await vscode.commands.executeCommand(commandId, testUrl, true);
         assert.ok(skillAccessStub.notCalled);
         assert.ok(openExternalStub.calledOnceWith(vscode.Uri.parse(testUrl)));
     });
@@ -50,10 +52,9 @@ describe("Command ask.container.openUrl", () => {
         sandbox.stub(skillHelper, "checkProfileSkillAccess");
         sandbox.stub(vscode.env, "openExternal").throws(new Error("foo"));
         try {
-            await vscode.commands.executeCommand("ask.container.openUrl", testUrl, true);
+            await vscode.commands.executeCommand(commandId, testUrl, true);
         } catch (e) {
-            assert.strictEqual(e.message, `Open URL failed. Reason: foo`);
-
+            assert.strictEqual(e.message, `Running the contributed command: '${commandId}' failed.`);
             return;
         }
         assert.fail("Should throw an error");

--- a/test/utils/commands/openWorkspace.test.ts
+++ b/test/utils/commands/openWorkspace.test.ts
@@ -9,8 +9,10 @@ import { stubTelemetryClient } from '../../../test/testUtilities';
 describe("Command ask.container.openWorkspace", () => {
     let command: OpenWorkspaceCommand;
     let sandbox: sinon.SinonSandbox;
+    let commandId: string;
     before(() => {
         command = new OpenWorkspaceCommand();
+        commandId = command.commandName;
     });
     after(() => {
         command.dispose();
@@ -24,8 +26,8 @@ describe("Command ask.container.openWorkspace", () => {
         sandbox.restore();
     });
     it("Constructor should work as expected", () => {
-        assert.strictEqual(command.title, "ask.container.openWorkspace");
-        assert.strictEqual(command.command, "ask.container.openWorkspace");
+        assert.strictEqual(command.title, commandId);
+        assert.strictEqual(command.command, commandId);
     });
 
     it("Should be able to call showOpenDialog with fixed config, and openWorkSpace folder with user provided path", async () => {
@@ -37,7 +39,7 @@ describe("Command ask.container.openWorkspace", () => {
             "canSelectFolders": true,
             "canSelectMany": false
         };
-        await vscode.commands.executeCommand("ask.container.openWorkspace");
+        await vscode.commands.executeCommand(commandId);
         assert.ok(showOpenDialogStub.calledOnceWith(expectedConfig));
         assert.ok(openWorkspaceStub.calledOnceWith(fakePath[0]));
     });
@@ -46,9 +48,9 @@ describe("Command ask.container.openWorkspace", () => {
         sandbox.stub(vscode.window, "showOpenDialog").resolves(undefined);
 
         try {
-            await vscode.commands.executeCommand("ask.container.openWorkspace");
+            await vscode.commands.executeCommand(commandId);
         } catch(e) {
-            assert.strictEqual(e.message, 'Cannot find a workspace to create the skill project.');
+            assert.strictEqual(e.message, `Running the contributed command: '${commandId}' failed.`);
 
             return;
         }


### PR DESCRIPTION
**Description of changes:**

- Due to the [recent vscode change](https://github.com/microsoft/vscode/commit/3ba967fd7eb97621b0e2a4fb0267b70323ffcf5f), errors raised by the extension are logged onto the extension host output window and a generic error message `Running the contributed command: <> failed.` is thrown. This leads to the unit test failures as can be checked [here](https://github.com/alexa/ask-toolkit-for-vscode/pull/95/checks?check_run_id=1841683081) 
- This PR fixes the issue, by changing the error message to be asserted.
- Tested the error messages thrown to the user are working as expected in the extension between vscode 1.52.1 and vscode 1.53. Also tested that the above mentioned commit is responsible for this change, by downgrading to the earlier version and running `npm test`, to be working as expected.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
