### PR TITLE
feat: support APL ExecuteCommands directive in toolkit simulator

### DIFF
--- a/media/previewApl/aplRenderUtils.js
+++ b/media/previewApl/aplRenderUtils.js
@@ -50,6 +50,10 @@ async function loadAplDoc(renderer, apl, datasources, deviceConfig, fatherDiv) {
     await renderer.init();
 }
 
+function renderExecuteCommands(commands) {
+    window.renderer.executeCommands(commands);
+}
+
 /**
  * Create content using AplRenderer
  * @param {string} apl, the document from directive

--- a/media/simulateSkill/simulateSkill.js
+++ b/media/simulateSkill/simulateSkill.js
@@ -482,6 +482,9 @@ async function handleAlexaResponse(message) {
     if (message.viewport !== undefined && message.documents !== undefined) {
         await updateAplViewPort(message.documents, message.dataSources, JSON.parse(message.viewport));
     }
+    if (message.aplCommands !== undefined && message.aplCommands.length > 0) {
+        renderExecuteCommands(JSON.stringify(message.aplCommands));
+    }
     extractSkillInfoData(message);
 }
 


### PR DESCRIPTION
*Issue #, if available:*
The toolkit simulator supports Alexa.Presentation.APL.RenderDocument directive, but not Alexa.Presentation.APL.ExecuteCommands directive. Related feature request: https://github.com/alexa/ask-toolkit-for-vscode/issues/67

*Description of changes:*
Change: catch ExecuteCommands directive from SMAPI response, then render it in APL preview.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
