### PR TITLE
fix: deploy status overview is not loading in 1.53.2 V

### DIFF
--- a/src/askContainer/webViews/deploySkillWebview/deployHostedSkillWebview.ts
+++ b/src/askContainer/webViews/deploySkillWebview/deployHostedSkillWebview.ts
@@ -172,6 +172,7 @@ export class DeployHostedSkillWebview extends AbstractWebView {
             vscode.Uri.file(path.join(this.extensionContext.extensionPath, "media", "skillDeploy.css"))
         );
         this.clearUpStateContentsCache();
+        this.refresh();
         return this.loader.renderView({
             name: "deployHostedSkill",
             js: true,

--- a/src/askContainer/webViews/deploySkillWebview/deployNonHostedSkillWebview.ts
+++ b/src/askContainer/webViews/deploySkillWebview/deployNonHostedSkillWebview.ts
@@ -123,6 +123,7 @@ export class DeployNonHostedSkillWebview extends AbstractWebView {
             vscode.Uri.file(path.join(this.extensionContext.extensionPath, "media", "skillDeploy.css"))
         );
         this.clearUpStateContentsCache();
+        this.refresh();
         return this.loader.renderView({
             name: "deployNonHostedSkill",
             js: true,

--- a/src/askContainer/webViews/welcomeScreenWebview.ts
+++ b/src/askContainer/webViews/welcomeScreenWebview.ts
@@ -58,6 +58,8 @@ export class WelcomeScreenWebview extends AbstractWebView {
             EXTENSION_STATE_KEY.CONFIG_SECTION_NAME).get(
                 EXTENSION_STATE_KEY.SHOW_WELCOME_SCREEN);
         this.checkGitInstallation();
+        this.getBlogUpdates();
+        this.getFeatureUpdates();
         return this.loader.renderView({
             name: WEB_VIEW_NAME.WELCOME_SCREEN,
             js: false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
1. The deploy status overview table in the skill deploy webview is not loading when first reveal in 1.53.2 v
2. The blog and feature info in the welcome screen webview is not updated when first reveal in 1.53.2 v

## Description
<!--- Describe your changes in detail -->

1. Call `refresh` method in `getHtmlForView` method whenever the deploy skill webview is generated.
2. Call `getBlogUpdates` and `getFeatureUpdates` in `getHtmlForView` method whenever the welcome webview is generated.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][https://github.com/alexa/ask-toolkit-for-vscode/issues], please link to the issue here -->

In the visual studio code 1.52.1 version, the `webviewPanel.onDidChangeViewState` is fired when first showing a webview. However, it does not work in 1.53.2 version. 

Post a question with `visual-studio-code` tag in stackflow : https://stackoverflow.com/questions/66426238/is-webviewpanel-ondidchangeviewstate-not-fired-when-first-showing-a-webview-in-t

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Open the "Skill deploy and build" webview, the deploy status overview table is able to load content automatically.
2. Open the "Alexa Skills Kit" welcome page, the Developer blog and features should be updated.


## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License

- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
