### PR TITLE
fix: consolidate deploy webviews messages in the constants file

### DIFF
--- a/src/askContainer/webViews/deploySkillWebview/deployHostedSkillWebview.ts
+++ b/src/askContainer/webViews/deploySkillWebview/deployHostedSkillWebview.ts
@@ -3,29 +3,38 @@
  *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  SPDX-License-Identifier: Apache-2.0
  *--------------------------------------------------------------------------------------------*/
-import * as fs from "fs-extra";
-import * as path from "path";
-import * as vscode from "vscode";
-import { AbstractWebView, Utils } from "../../../runtime";
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { AbstractWebView, Utils } from '../../../runtime';
 
-import { BRANCH_TO_STAGE, DEFAULT_PROFILE, SKILL, SKILL_FOLDER, TELEMETRY_EVENTS } from "../../../constants";
+import {
+    BRANCH_TO_STAGE,
+    DEFAULT_PROFILE,
+    SKILL,
+    SKILL_FOLDER,
+    TELEMETRY_EVENTS,
+    DEPLOY_HOSTED_SKILL_PACKAGE_STATE_CONTENT,
+    DEPLOY_HOSTED_LOCAL_CHANGE_STATE_CONTENT,
+    DEPLOY_HOSTED_SKILL_CODE_STATE_CONTENT
+} from '../../../constants';
 import { AskStates } from '../../../models/resourcesConfig/askStates';
-import { ViewLoader } from "../../../utils/webViews/viewLoader";
-import { DeployHostedSkillManager } from "./deployHostedSkillManager";
-import { getSkillDetailsFromWorkspace } from "../../../utils/skillHelper";
-import { getOrInstantiateGitApi } from "../../../utils/gitHelper";
-import { getSkillPackageStatus } from "../../../utils/skillPackageHelper";
-import { API, Change, Repository } from "../../../@types/git";
-import { Logger } from "../../../logger";
-import { AskError, loggableAskError } from "../../../exceptions";
-import { getSkillFolderInWs } from "../../../utils/workspaceHelper";
-import { ext } from "../../../extensionGlobals";
-import { isNonEmptyString } from "../../../runtime/lib/utils";
-import { TelemetryClient } from "../../../runtime/lib/telemetry";
+import { ViewLoader } from '../../../utils/webViews/viewLoader';
+import { DeployHostedSkillManager } from './deployHostedSkillManager';
+import { getSkillDetailsFromWorkspace } from '../../../utils/skillHelper';
+import { getOrInstantiateGitApi } from '../../../utils/gitHelper';
+import { getSkillPackageStatus } from '../../../utils/skillPackageHelper';
+import { API, Change, Repository } from '../../../@types/git';
+import { Logger } from '../../../logger';
+import { AskError, loggableAskError } from '../../../exceptions';
+import { getSkillFolderInWs } from '../../../utils/workspaceHelper';
+import { ext } from '../../../extensionGlobals';
+import { isNonEmptyString } from '../../../runtime/lib/utils';
+import { TelemetryClient } from '../../../runtime/lib/telemetry';
 
 enum DeployType {
     gitPush,
-    deploySkillPackage
+    deploySkillPackage,
 }
 
 enum LocalChangesStates {
@@ -80,10 +89,10 @@ export class DeployHostedSkillWebview extends AbstractWebView {
 
     constructor(viewTitle: string, viewId: string, context: vscode.ExtensionContext) {
         super(viewTitle, viewId, context);
-        this.loader = new ViewLoader(this.extensionContext, "deployHostedSkill", this);
+        this.loader = new ViewLoader(this.extensionContext, 'deployHostedSkill', this);
         void getOrInstantiateGitApi(context).then(value => {
             if (value === undefined) {
-                throw loggableAskError("No git extension found.", null, true);
+                throw loggableAskError('No git extension found.', null, true);
             }
             this.gitApi = value;
         });
@@ -109,30 +118,32 @@ export class DeployHostedSkillWebview extends AbstractWebView {
 
     async onReceiveMessageListener(message: string): Promise<void> {
         Logger.debug(`Calling method: ${this.viewId}.onReceiveMessageListener, args: `, message);
-        if (message === "refresh") {
+        if (message === 'refresh') {
             ext.skillPackageWatcher.validate();
             void this.refresh(true);
-        } else if (message === "deploySkill" || message === "forceDeploy") {
+        } else if (message === 'deploySkill' || message === 'forceDeploy') {
             const telemetryClient = new TelemetryClient({});
             const telemetryEventName = TELEMETRY_EVENTS.DEPLOY_HOSTED_SKILL_TELEMETRY_EVENT;
             try {
                 telemetryClient.startAction(telemetryEventName, 'event');
                 const skillFolder = getSkillFolderInWs(this.extensionContext);
                 if (skillFolder === undefined) {
-                    throw new AskError("No skill folder found in the workspace");
+                    throw new AskError('No skill folder found in the workspace');
                 }
                 this.skillRepo = this.gitApi.getRepository(skillFolder);
                 if (this.skillRepo === null) {
-                    throw new AskError("No skill repository found. Please make sure the skill exists in the Developer Console and download it again.");
+                    throw new AskError(
+                        'No skill repository found. Please make sure the skill exists in the Developer Console and download it again.'
+                    );
                 }
                 await this.updateCurrentRepoState();
                 const branch = this.currentRepoState.branch;
                 if (branch === undefined) {
-                    throw new AskError("Failed to fetch git branch");
+                    throw new AskError('Failed to fetch git branch');
                 }
                 this.getPanel().webview.html = this.loader.renderView({
-                    name: "deployInProgress",
-                    errorMsg: "Skill deployment in progress...",
+                    name: 'deployInProgress',
+                    errorMsg: 'Skill deployment in progress...',
                 });
                 const deployType = await this.validateAndGetDeployType(skillFolder, this.skillRepo, branch, message);
 
@@ -152,13 +163,13 @@ export class DeployHostedSkillWebview extends AbstractWebView {
                 this.dispose();
                 throw loggableAskError(`Skill deploy failed`, err, true);
             }
-        } else if (message === "exportSkillPackage") {
-            const hasDownloaded = await vscode.commands.executeCommand("ask.exportSkillPackage");
+        } else if (message === 'exportSkillPackage') {
+            const hasDownloaded = await vscode.commands.executeCommand('ask.exportSkillPackage');
             if (hasDownloaded === true) {
                 void this.refresh(true);
             }
         } else {
-            throw loggableAskError("Unexpected message received from webview.");
+            throw loggableAskError('Unexpected message received from webview.');
         }
     }
 
@@ -166,47 +177,55 @@ export class DeployHostedSkillWebview extends AbstractWebView {
         Logger.debug(`Calling method: ${this.viewId}.getHtmlForView`);
         const skillFolder = getSkillFolderInWs(this.extensionContext);
         if (skillFolder === undefined) {
-            throw new AskError("No skill folder found in the workspace");
+            throw new AskError('No skill folder found in the workspace');
         }
-        this.askStates = new AskStates(skillFolder.fsPath)
+        this.askStates = new AskStates(skillFolder.fsPath);
         const skillDetails = getSkillDetailsFromWorkspace(this.extensionContext);
         const skillId: string = skillDetails.skillId;
         const skillName: string = skillDetails.skillName;
         const webview: vscode.Webview = this.getWebview();
         const skillDeployCss: vscode.Uri = webview.asWebviewUri(
-            vscode.Uri.file(path.join(this.extensionContext.extensionPath, "media", "skillDeploy.css"))
+            vscode.Uri.file(path.join(this.extensionContext.extensionPath, 'media', 'skillDeploy.css'))
         );
         this.clearUpStateContentsCache();
         this.refresh();
         return this.loader.renderView({
-            name: "deployHostedSkill",
+            name: 'deployHostedSkill',
             js: true,
             args: { skillId, skillName, skillDeployCss },
         });
     }
 
-    private async validateAndGetDeployType(skillFolder: vscode.Uri, skillRepo: Repository, branch: string, message: string): Promise<DeployType> {
+    private async validateAndGetDeployType(
+        skillFolder: vscode.Uri,
+        skillRepo: Repository,
+        branch: string,
+        message: string
+    ): Promise<DeployType> {
         const changesStateContent = this.getLocalChangesState(branch);
-        if (changesStateContent.state !== LocalChangesStates.committed &&
-            !(message === "forceDeploy" && changesStateContent.state !== LocalChangesStates.invalidBranch)) {
+        if (
+            changesStateContent.state !== LocalChangesStates.committed &&
+            !(message === 'forceDeploy' && changesStateContent.state !== LocalChangesStates.invalidBranch)
+        ) {
             void this.refresh();
             throw new AskError(changesStateContent.text);
         }
         const skillPackageStatesContent = await this.getSkillPackageSyncState(skillFolder, branch);
-        if (skillPackageStatesContent.state !== SkillPackageStates.upToDate && 
-            !(message === "forceDeploy" && skillPackageStatesContent.state === SkillPackageStates.outOfSync) &&
-            !(message === "forceDeploy" && skillPackageStatesContent.state === SkillPackageStates.noETag)) {
+        if (
+            skillPackageStatesContent.state !== SkillPackageStates.upToDate &&
+            !(message === 'forceDeploy' && skillPackageStatesContent.state === SkillPackageStates.outOfSync) &&
+            !(message === 'forceDeploy' && skillPackageStatesContent.state === SkillPackageStates.noETag)
+        ) {
             void this.refresh();
             throw new AskError(skillPackageStatesContent.text);
         }
-        
+
         const skillCodeState = await this.getSkillCodeSyncStates(skillFolder, skillRepo, branch);
-        if (skillCodeState.state !== SkillCodeStates.upToDate && 
-            skillCodeState.state !== SkillCodeStates.ahead) {
+        if (skillCodeState.state !== SkillCodeStates.upToDate && skillCodeState.state !== SkillCodeStates.ahead) {
             void this.refresh();
             throw new AskError(skillCodeState.text);
         }
-        if (message === "forceDeploy" && skillCodeState.state === SkillCodeStates.upToDate) {
+        if (message === 'forceDeploy' && skillCodeState.state === SkillCodeStates.upToDate) {
             return DeployType.deploySkillPackage;
         } else {
             return DeployType.gitPush;
@@ -225,11 +244,13 @@ export class DeployHostedSkillWebview extends AbstractWebView {
         try {
             const skillFolder = getSkillFolderInWs(this.extensionContext);
             if (skillFolder === undefined) {
-                throw new AskError("No skill folder found in the workspace");
+                throw new AskError('No skill folder found in the workspace');
             }
             this.skillRepo = this.gitApi.getRepository(skillFolder);
             if (this.skillRepo === null) {
-                throw new AskError("No skill repository found. Please make sure the skill exists in the Developer Console and download it again.");
+                throw new AskError(
+                    'No skill repository found. Please make sure the skill exists in the Developer Console and download it again.'
+                );
             }
             this.skillRepo.state.onDidChange(() => {
                 if (this.isDisposed() === true) {
@@ -240,14 +261,14 @@ export class DeployHostedSkillWebview extends AbstractWebView {
             await this.updateCurrentRepoState();
             const branch = this.currentRepoState.branch;
             if (branch === undefined) {
-                throw new AskError("Failed to fetch git branch");
+                throw new AskError('Failed to fetch git branch');
             }
             await this.updateLocalChangesState(branch);
             await this.updateSkillPackageSyncState(skillFolder, branch);
             await this.updateSkillCodeSyncState(skillFolder, this.skillRepo, branch);
         } catch (error) {
             await this.postMessage(error);
-            throw loggableAskError("Skill deploy and build page refresh failed", error, true);
+            throw loggableAskError('Skill deploy and build page refresh failed', error, true);
         }
     }
 
@@ -300,7 +321,11 @@ export class DeployHostedSkillWebview extends AbstractWebView {
         await this.postMessage();
     }
 
-    private async updateSkillCodeSyncState(skillFolder: vscode.Uri, skillRepo: Repository, branch: string): Promise<void> {
+    private async updateSkillCodeSyncState(
+        skillFolder: vscode.Uri,
+        skillRepo: Repository,
+        branch: string
+    ): Promise<void> {
         this.skillCodeSyncStateContent = await this.getSkillCodeSyncStates(skillFolder, skillRepo, branch);
         await this.postMessage();
     }
@@ -315,7 +340,7 @@ export class DeployHostedSkillWebview extends AbstractWebView {
             skillPackageStatesContent: this.skillPackageStatesContent,
             skillCodeSyncStateContent: this.skillCodeSyncStateContent,
             states: { LocalChangesStates, SkillPackageStates, SkillCodeStates },
-            error
+            error,
         });
     }
 
@@ -324,10 +349,7 @@ export class DeployHostedSkillWebview extends AbstractWebView {
         if (BRANCH_TO_STAGE[branch] === undefined) {
             return this.resolveLocalChangeStateContent(LocalChangesStates.invalidBranch, branch);
         }
-        if (
-            this.currentRepoState.changesWithHead !== undefined &&
-            this.currentRepoState.changesWithHead.length !== 0
-        ) {
+        if (this.currentRepoState.changesWithHead !== undefined && this.currentRepoState.changesWithHead.length !== 0) {
             return this.resolveLocalChangeStateContent(LocalChangesStates.unstaged, branch);
         }
         if (
@@ -350,31 +372,31 @@ export class DeployHostedSkillWebview extends AbstractWebView {
         if (state === LocalChangesStates.untracked) {
             return {
                 state,
-                text: `Untracked file(s) present in the current branch <code>${branch}</code>. Use <code>git add</code> to track.`,
+                text: DEPLOY_HOSTED_LOCAL_CHANGE_STATE_CONTENT.UNTRACKED(branch),
                 valid: false,
             };
         } else if (state === LocalChangesStates.unstaged || state === LocalChangesStates.staged) {
             return {
                 state,
-                text: `Changes exist in the current branch <code>${branch}</code>. Use <code>git add</code> and <code>git commit</code> to commit changes.`,
+                text: DEPLOY_HOSTED_LOCAL_CHANGE_STATE_CONTENT.UNSTAGED(branch),
                 valid: false,
             };
         } else if (state === LocalChangesStates.noChanges) {
             return {
                 state,
-                text: `There are no changes in the current branch <code>${branch}</code> to deploy. To deploy this skill, commit a change to the project.`,
+                text: DEPLOY_HOSTED_LOCAL_CHANGE_STATE_CONTENT.NO_CHANGE(branch),
                 valid: false,
             };
         } else if (state === LocalChangesStates.invalidBranch) {
             return {
                 state,
-                text: `The current branch must be either <code>master</code> or <code>prod</code>.</p> Merge changes to these branches to deploy the skill.`,
+                text: DEPLOY_HOSTED_LOCAL_CHANGE_STATE_CONTENT.INVALID_BRANCH,
                 valid: false,
             };
         } else {
             return {
                 state: LocalChangesStates.committed,
-                text: `Committed changes exist in the current branch <code>${branch}</code>. Ready to deploy.`,
+                text: DEPLOY_HOSTED_LOCAL_CHANGE_STATE_CONTENT.COMMITTED(branch),
                 valid: true,
             };
         }
@@ -393,7 +415,7 @@ export class DeployHostedSkillWebview extends AbstractWebView {
         const skillDetails = getSkillDetailsFromWorkspace(this.extensionContext);
         const skillId = skillDetails.skillId;
         if (!isNonEmptyString(skillId)) {
-            throw new AskError("Failed to get the skill id in .ask/ask-states.json.");
+            throw new AskError('Failed to get the skill id in .ask/ask-states.json.');
         }
         let skillPackageStatus;
         try {
@@ -403,7 +425,7 @@ export class DeployHostedSkillWebview extends AbstractWebView {
         }
         const remoteETag = skillPackageStatus.skill?.eTag;
         const localETag = this.getLocalETag(skillFolder, skillStage);
-        if (localETag === undefined || typeof localETag !== "string") {
+        if (localETag === undefined || typeof localETag !== 'string') {
             return this.resolveSkillPackageStateContent(SkillPackageStates.noETag);
         }
         return localETag === remoteETag
@@ -428,46 +450,47 @@ export class DeployHostedSkillWebview extends AbstractWebView {
         if (state === SkillPackageStates.outOfSync) {
             return {
                 state,
-                text: "Skill package contents may not be up-to-date with Alexa service. Please ensure you have the latest changes before deploying.",
+                text: DEPLOY_HOSTED_SKILL_PACKAGE_STATE_CONTENT.OUT_OF_SYNC,
                 valid: false,
             };
         } else if (state === SkillPackageStates.noETag) {
             return {
                 state,
-                text:
-                    "Skill package contents may not be up-to-date with Alexa service. Please ensure you have the latest changes before deploying.",
+                text: DEPLOY_HOSTED_SKILL_PACKAGE_STATE_CONTENT.NO_ETAG,
                 valid: false,
             };
         } else if (state === SkillPackageStates.liveSkill) {
             return {
                 state,
-                text:
-                    "To update your live skill package, please submit your changes for certification in the Alexa developer console.",
+                text: DEPLOY_HOSTED_SKILL_PACKAGE_STATE_CONTENT.LIVE_SKILL,
                 valid: false,
-            };   
+            };
         } else if (state === SkillPackageStates.noSkillPackage) {
             return {
                 state,
-                text:
-                    "There is no skill-package found in the workspace. Merge skill-package to this branch to deploy the skill",
+                text: DEPLOY_HOSTED_SKILL_PACKAGE_STATE_CONTENT.NO_SKILL_PACKAGE,
                 valid: false,
             };
         } else if (state === SkillPackageStates.serviceError) {
             return {
                 state,
-                text: error === undefined ? "Service error." : `Service Error: ${error}`,
+                text: DEPLOY_HOSTED_SKILL_PACKAGE_STATE_CONTENT.SERVICE_ERROR(error),
                 valid: false,
             };
         } else {
             return {
                 state: SkillPackageStates.upToDate,
-                text: "Last deployed skill package is up to date with Alexa service.",
+                text: DEPLOY_HOSTED_SKILL_PACKAGE_STATE_CONTENT.UP_TO_DATE,
                 valid: true,
             };
         }
     }
 
-    private async getSkillCodeSyncStates(skillFolder: vscode.Uri, skillRepo: Repository, branch: string): Promise<StateContent> {
+    private async getSkillCodeSyncStates(
+        skillFolder: vscode.Uri,
+        skillRepo: Repository,
+        branch: string
+    ): Promise<StateContent> {
         Logger.verbose(`Calling method: ${this.viewId}.syncSkillCodeSyncWithRemote, args:`, skillFolder);
         const skillCodePath = path.join(skillFolder.fsPath, SKILL_FOLDER.LAMBDA.NAME);
         if (!fs.existsSync(skillCodePath)) {
@@ -482,7 +505,7 @@ export class DeployHostedSkillWebview extends AbstractWebView {
         } catch (error) {
             return this.resolveSkillCodeStateContent(SkillCodeStates.serviceError, error);
         }
-        if ((aheadCommits !== undefined && aheadCommits !== 0) && (behindCommits !== undefined && behindCommits !== 0)) {
+        if (aheadCommits !== undefined && aheadCommits !== 0 && behindCommits !== undefined && behindCommits !== 0) {
             return this.resolveSkillCodeStateContent(SkillCodeStates.diverged);
         }
         if (aheadCommits !== undefined && aheadCommits !== 0) {
@@ -499,38 +522,37 @@ export class DeployHostedSkillWebview extends AbstractWebView {
         if (state === SkillCodeStates.outOfSync) {
             return {
                 state,
-                text:
-                    "Current files conflict with deployed version. Use <code>git pull</code> to merge the remote branch into yours.",
+                text: DEPLOY_HOSTED_SKILL_CODE_STATE_CONTENT.OUT_OF_SYNC,
                 valid: false,
             };
         } else if (state === SkillCodeStates.noSkillCode) {
             return {
                 state,
-                text: "There is no AWS Lambda source code found in the workspace.",
+                text: DEPLOY_HOSTED_SKILL_CODE_STATE_CONTENT.NO_SKILL_CODE,
                 valid: false,
             };
         } else if (state === SkillCodeStates.ahead) {
             return {
                 state,
-                text: "Your skill code is ahead of the remote version.",
+                text: DEPLOY_HOSTED_SKILL_CODE_STATE_CONTENT.AHEAD,
                 valid: true,
             };
         } else if (state === SkillCodeStates.diverged) {
             return {
                 state,
-                text: "Your skill code and the remote version have diverged. Use <code>git status</code> to get more details.",
+                text: DEPLOY_HOSTED_SKILL_CODE_STATE_CONTENT.DIVERGED,
                 valid: false,
             };
         } else if (state === SkillCodeStates.serviceError) {
             return {
                 state,
-                text: error === undefined ? "Service error." : `Service Error: ${error}`,
+                text: DEPLOY_HOSTED_SKILL_CODE_STATE_CONTENT.SERVICE_ERROR(error),
                 valid: false,
             };
         } else {
             return {
                 state: SkillCodeStates.upToDate,
-                text: `Your skill code is up to date with Alexa service.`,
+                text: DEPLOY_HOSTED_SKILL_CODE_STATE_CONTENT.UP_TO_DATE,
                 valid: true,
             };
         }

--- a/src/askContainer/webViews/deploySkillWebview/deployNonHostedSkillWebview.ts
+++ b/src/askContainer/webViews/deploySkillWebview/deployNonHostedSkillWebview.ts
@@ -3,27 +3,30 @@
  *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  SPDX-License-Identifier: Apache-2.0
  *--------------------------------------------------------------------------------------------*/
-import * as fs from "fs-extra";
-import * as path from "path";
-import * as vscode from "vscode";
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as vscode from 'vscode';
 
-import { DEFAULT_PROFILE, SKILL, TELEMETRY_EVENTS } from "../../../constants";
-import { AbstractWebView, Utils } from "../../../runtime";
-import { AskStates } from '../../../models/resourcesConfig/askStates';
-import { getHash } from "../../../utils/hashHelper";
-import { ViewLoader } from "../../../utils/webViews/viewLoader";
-import { DeployNonHostedSkillManager } from "./deployNonHostedSkillManager";
 import {
-    getSkillMetadataSrc,
-    getSkillDetailsFromWorkspace,
-} from "../../../utils/skillHelper";
-import { getSkillPackageStatus } from "../../../utils/skillPackageHelper";
-import { Logger } from "../../../logger";
-import { AskError, loggableAskError } from "../../../exceptions";
-import { getSkillFolderInWs } from "../../../utils/workspaceHelper";
-import { ext } from "../../../extensionGlobals";
-import { isNonEmptyString } from "../../../runtime/lib/utils";
-import { TelemetryClient } from "../../../runtime/lib/telemetry";
+    DEFAULT_PROFILE,
+    SKILL,
+    TELEMETRY_EVENTS,
+    DEPLOY_SELF_HOSTED_SKILL_PACKAGE_STATE_CONTENT,
+    DEPLOY_SELF_HOSTED_LOCAL_CHANGE_STATE_CONTENT,
+} from '../../../constants';
+import { AbstractWebView, Utils } from '../../../runtime';
+import { AskStates } from '../../../models/resourcesConfig/askStates';
+import { getHash } from '../../../utils/hashHelper';
+import { ViewLoader } from '../../../utils/webViews/viewLoader';
+import { DeployNonHostedSkillManager } from './deployNonHostedSkillManager';
+import { getSkillMetadataSrc, getSkillDetailsFromWorkspace } from '../../../utils/skillHelper';
+import { getSkillPackageStatus } from '../../../utils/skillPackageHelper';
+import { Logger } from '../../../logger';
+import { AskError, loggableAskError } from '../../../exceptions';
+import { getSkillFolderInWs } from '../../../utils/workspaceHelper';
+import { ext } from '../../../extensionGlobals';
+import { isNonEmptyString } from '../../../runtime/lib/utils';
+import { TelemetryClient } from '../../../runtime/lib/telemetry';
 
 enum LocalChangesStates {
     noChanges,
@@ -54,7 +57,7 @@ export class DeployNonHostedSkillWebview extends AbstractWebView {
 
     constructor(viewTitle: string, viewId: string, context: vscode.ExtensionContext) {
         super(viewTitle, viewId, context);
-        this.loader = new ViewLoader(this.extensionContext, "deployNonHostedSkill", this);
+        this.loader = new ViewLoader(this.extensionContext, 'deployNonHostedSkill', this);
     }
 
     // eslint-disable-next-line @typescript-eslint/require-await
@@ -70,13 +73,13 @@ export class DeployNonHostedSkillWebview extends AbstractWebView {
         Logger.debug(`Calling method: ${this.viewId}.onReceiveMessageListener, args: `, message);
         const skillFolder = getSkillFolderInWs(this.extensionContext);
         if (skillFolder === undefined) {
-            throw loggableAskError("No skill folder found in the workspace.", null, true);
+            throw loggableAskError('No skill folder found in the workspace.', null, true);
         }
 
-        if (message === "refresh") {
+        if (message === 'refresh') {
             ext.skillPackageWatcher.validate();
             void this.refresh(true);
-        } else if (message === "deploySkill" || message === "forceDeploy") {
+        } else if (message === 'deploySkill' || message === 'forceDeploy') {
             const telemetryClient = new TelemetryClient({});
             const telemetryEventName = TELEMETRY_EVENTS.DEPLOY_SELF_HOSTED_SKILL_TELEMETRY_EVENT;
             try {
@@ -85,8 +88,8 @@ export class DeployNonHostedSkillWebview extends AbstractWebView {
                 profile = profile ?? DEFAULT_PROFILE;
                 await this.validateAllDeployStates(skillFolder, message, profile);
                 this.getPanel().webview.html = this.loader.renderView({
-                    name: "deployInProgress",
-                    errorMsg: "Skill deployment in progress...",
+                    name: 'deployInProgress',
+                    errorMsg: 'Skill deployment in progress...',
                 });
                 const { skillPackageAbsPath } = getSkillMetadataSrc(skillFolder.fsPath, profile);
                 const currentHash = await getHash(skillPackageAbsPath);
@@ -96,20 +99,20 @@ export class DeployNonHostedSkillWebview extends AbstractWebView {
                     skillFolder,
                     currentHash.hash
                 );
-                await deployNonHostedSkillManager.deploySkill(this, message === "forceDeploy", eTag);
+                await deployNonHostedSkillManager.deploySkill(this, message === 'forceDeploy', eTag);
                 void telemetryClient.sendData();
             } catch (err) {
                 void telemetryClient.sendData(err);
                 this.dispose();
                 throw loggableAskError(`Skill deploy failed`, err, true);
             }
-        } else if (message === "exportSkillPackage") {
-            const hasDownloaded = await vscode.commands.executeCommand("ask.exportSkillPackage");
+        } else if (message === 'exportSkillPackage') {
+            const hasDownloaded = await vscode.commands.executeCommand('ask.exportSkillPackage');
             if (hasDownloaded === true) {
                 void this.refresh(true);
             }
         } else {
-            throw loggableAskError("Unexpected message received from webview.");
+            throw loggableAskError('Unexpected message received from webview.');
         }
     }
 
@@ -117,7 +120,7 @@ export class DeployNonHostedSkillWebview extends AbstractWebView {
         Logger.debug(`Calling method: ${this.viewId}.getHtmlForView`);
         const skillFolder = getSkillFolderInWs(this.extensionContext);
         if (skillFolder === undefined) {
-            throw new AskError("No skill folder found in the workspace");
+            throw new AskError('No skill folder found in the workspace');
         }
         this.askStates = new AskStates(skillFolder.fsPath);
         const skillDetails = getSkillDetailsFromWorkspace(this.extensionContext);
@@ -125,12 +128,12 @@ export class DeployNonHostedSkillWebview extends AbstractWebView {
         this.skillName = skillDetails.skillName;
         const webview: vscode.Webview = this.getWebview();
         const skillDeployCss: vscode.Uri = webview.asWebviewUri(
-            vscode.Uri.file(path.join(this.extensionContext.extensionPath, "media", "skillDeploy.css"))
+            vscode.Uri.file(path.join(this.extensionContext.extensionPath, 'media', 'skillDeploy.css'))
         );
         this.clearUpStateContentsCache();
         this.refresh();
         return this.loader.renderView({
-            name: "deployNonHostedSkill",
+            name: 'deployNonHostedSkill',
             js: true,
             args: { skillId, skillName: this.skillName, skillDeployCss },
         });
@@ -138,8 +141,7 @@ export class DeployNonHostedSkillWebview extends AbstractWebView {
 
     private async validateAllDeployStates(skillFolder: vscode.Uri, message: string, profile: string) {
         const changesStateContent = await this.getLocalChangesState(skillFolder);
-        if (changesStateContent.state === LocalChangesStates.noChanges &&
-            message !== "forceDeploy") {
+        if (changesStateContent.state === LocalChangesStates.noChanges && message !== 'forceDeploy') {
             void this.refresh();
             throw new AskError(changesStateContent.text);
         }
@@ -147,8 +149,8 @@ export class DeployNonHostedSkillWebview extends AbstractWebView {
         const skillPackageStatesContent = await this.getSkillPackageState(skillFolder, skillDetails.skillId, profile);
         if (
             skillPackageStatesContent.state !== SkillPackageStates.upToDate &&
-            !(message === "forceDeploy" && skillPackageStatesContent.state === SkillPackageStates.outOfSync) &&
-            !(message === "forceDeploy" && skillPackageStatesContent.state === SkillPackageStates.noETag)
+            !(message === 'forceDeploy' && skillPackageStatesContent.state === SkillPackageStates.outOfSync) &&
+            !(message === 'forceDeploy' && skillPackageStatesContent.state === SkillPackageStates.noETag)
         ) {
             void this.refresh();
             throw new AskError(skillPackageStatesContent.text);
@@ -168,7 +170,7 @@ export class DeployNonHostedSkillWebview extends AbstractWebView {
         try {
             const skillFolder = getSkillFolderInWs(this.extensionContext);
             if (skillFolder === undefined) {
-                throw new AskError("No skill folder found in the workspace");
+                throw new AskError('No skill folder found in the workspace');
             }
             const skillDetails = getSkillDetailsFromWorkspace(this.extensionContext);
             this.skillName = skillDetails.skillName;
@@ -180,7 +182,7 @@ export class DeployNonHostedSkillWebview extends AbstractWebView {
             await this.updateSkillPackageSyncState(skillFolder, skillDetails.skillId, profile);
         } catch (error) {
             this.postMessage(error);
-            throw loggableAskError("Skill deploy and build page refresh failed", error, true);
+            throw loggableAskError('Skill deploy and build page refresh failed', error, true);
         }
     }
 
@@ -211,7 +213,7 @@ export class DeployNonHostedSkillWebview extends AbstractWebView {
             changesStateContent: this.changesStateContent,
             skillPackageStatesContent: this.skillPackageStatesContent,
             states: { LocalChangesStates, SkillPackageStates },
-            error
+            error,
         });
     }
 
@@ -231,7 +233,7 @@ export class DeployNonHostedSkillWebview extends AbstractWebView {
                 ? this.resolveLocalChangeStateContent(LocalChangesStates.changesExist)
                 : this.resolveLocalChangeStateContent(LocalChangesStates.noChanges);
         } catch (error) {
-            throw loggableAskError("Failed to get local changes state", error);
+            throw loggableAskError('Failed to get local changes state', error);
         }
     }
 
@@ -240,13 +242,13 @@ export class DeployNonHostedSkillWebview extends AbstractWebView {
         if (state === LocalChangesStates.noChanges) {
             return {
                 state,
-                text: "There are no changes to deploy. To deploy this skill, make a change to the project.",
+                text: DEPLOY_SELF_HOSTED_LOCAL_CHANGE_STATE_CONTENT.NO_CHANGE,
                 valid: false,
             };
         } else {
             return {
                 state,
-                text: "Changes exist in the skill. Ready to deploy.",
+                text: DEPLOY_SELF_HOSTED_LOCAL_CHANGE_STATE_CONTENT.CHANGES_EXIST,
                 valid: true,
             };
         }
@@ -263,7 +265,7 @@ export class DeployNonHostedSkillWebview extends AbstractWebView {
             return this.resolveSkillPackageStateContent(SkillPackageStates.noSkillPackage);
         }
         if (!isNonEmptyString(skillId)) {
-            throw new AskError("Failed to get the skill id in .ask/ask-states.json.");
+            throw new AskError('Failed to get the skill id in .ask/ask-states.json.');
         }
         let skillPackageStatus;
         try {
@@ -273,7 +275,7 @@ export class DeployNonHostedSkillWebview extends AbstractWebView {
         }
         const remoteETag = skillPackageStatus.skill?.eTag;
         const localETag = this.getLocalETag(skillFolder);
-        if (localETag === undefined || typeof localETag !== "string") {
+        if (localETag === undefined || typeof localETag !== 'string') {
             return this.resolveSkillPackageStateContent(SkillPackageStates.noETag);
         }
         return localETag === remoteETag
@@ -286,33 +288,31 @@ export class DeployNonHostedSkillWebview extends AbstractWebView {
         if (state === SkillPackageStates.outOfSync) {
             return {
                 state,
-                text: "Skill package contents may not be up-to-date with Alexa service. Please ensure you have the latest changes before deploying.",
+                text: DEPLOY_SELF_HOSTED_SKILL_PACKAGE_STATE_CONTENT.OUT_OF_SYNC,
                 valid: false,
             };
         } else if (state === SkillPackageStates.noETag) {
             return {
                 state,
-                text:
-                    "Skill package contents may not be up-to-date with Alexa service. Please ensure you have the latest changes before deploying.",
+                text: DEPLOY_SELF_HOSTED_SKILL_PACKAGE_STATE_CONTENT.NO_ETAG,
                 valid: false,
             };
         } else if (state === SkillPackageStates.noSkillPackage) {
             return {
                 state,
-                text:
-                    "There is no skill-package found in the workspace. Merge skill-package to this branch to deploy the skill.",
+                text: DEPLOY_SELF_HOSTED_SKILL_PACKAGE_STATE_CONTENT.NO_SKILL_PACKAGE,
                 valid: false,
             };
         } else if (state === SkillPackageStates.serviceError) {
             return {
                 state,
-                text: error === undefined ? "Service error." : `Service Error: ${error}`,
+                text: DEPLOY_SELF_HOSTED_SKILL_PACKAGE_STATE_CONTENT.SERVICE_ERROR(error),
                 valid: false,
             };
         } else {
             return {
                 state: SkillPackageStates.upToDate,
-                text: "Last deployed skill package is up to date with Alexa service.",
+                text: DEPLOY_SELF_HOSTED_SKILL_PACKAGE_STATE_CONTENT.UP_TO_DATE,
                 valid: true,
             };
         }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -491,3 +491,42 @@ export const TELEMETRY_NOTIFICATION_MESSAGE =
 '"Alexa Skills Kit Configuration" section in your user settings.';
 
 export const SKILL_PACKAGE_FORMAT_GUID = 'Please follow [this guide](https://developer.amazon.com/en-US/docs/alexa/smapi/skill-package-api-reference.html#skill-package-format) to upgrade your skill-package folder structure. For more detailed skill-package format, please check .ask/schema/skillPackageSchema.json.';
+
+export const DEPLOY_SELF_HOSTED_SKILL_PACKAGE_STATE_CONTENT = Object.freeze({
+    OUT_OF_SYNC: "Skill package contents may not be up-to-date with Alexa service. Please ensure you have the latest changes before deploying.",
+    NO_ETAG: "Skill package contents may not be up-to-date with Alexa service. Please ensure you have the latest changes before deploying.",
+    NO_SKILL_PACKAGE: "There is no skill-package found in the workspace. Merge skill-package to this branch to deploy the skill.",
+    SERVICE_ERROR: (error?: string) => error === undefined ? "Service error." : `Service Error: ${error}`,
+    UP_TO_DATE: "Last deployed skill package is up to date with Alexa service."
+});
+
+export const DEPLOY_SELF_HOSTED_LOCAL_CHANGE_STATE_CONTENT = Object.freeze({
+    NO_CHANGE: "There are no changes to deploy. To deploy this skill, make a change to the project.",
+    CHANGES_EXIST: "Changes exist in the skill. Ready to deploy.",
+});
+
+export const DEPLOY_HOSTED_SKILL_PACKAGE_STATE_CONTENT = Object.freeze({
+    OUT_OF_SYNC: "Skill package contents may not be up-to-date with Alexa service. Please ensure you have the latest changes before deploying.",
+    NO_ETAG: "Skill package contents may not be up-to-date with Alexa service. Please ensure you have the latest changes before deploying.",
+    LIVE_SKILL: "To update your live skill package, please submit your changes for certification in the Alexa developer console.",
+    NO_SKILL_PACKAGE: "There is no skill-package found in the workspace. Merge skill-package to this branch to deploy the skill.",
+    SERVICE_ERROR: (error?: string) => error === undefined ? "Service error." : `Service Error: ${error}`,
+    UP_TO_DATE: "Last deployed skill package is up to date with Alexa service."
+});
+
+export const DEPLOY_HOSTED_LOCAL_CHANGE_STATE_CONTENT = Object.freeze({
+    UNTRACKED: (branch: string) => `Untracked file(s) present in the current branch <code>${branch}</code>. Use <code>git add</code> to track.`,
+    UNSTAGED: (branch: string) => `Changes exist in the current branch <code>${branch}</code>. Use <code>git add</code> and <code>git commit</code> to commit changes.`,
+    NO_CHANGE: (branch: string) => `There are no changes in the current branch <code>${branch}</code> to deploy. To deploy this skill, commit a change to the project.`,
+    INVALID_BRANCH: "The current branch must be either <code>master</code> or <code>prod</code>.</p> Merge changes to these branches to deploy the skill.",
+    COMMITTED: (branch: string) => `Committed changes exist in the current branch <code>${branch}</code>. Ready to deploy.`
+});
+
+export const DEPLOY_HOSTED_SKILL_CODE_STATE_CONTENT = Object.freeze({
+    OUT_OF_SYNC: "Current files conflict with deployed version. Use <code>git pull</code> to merge the remote branch into yours.",
+    NO_SKILL_CODE: "There is no AWS Lambda source code found in the workspace.",
+    AHEAD: "Your skill code is ahead of the remote version.",
+    DIVERGED: "Your skill code and the remote version have diverged. Use <code>git status</code> to get more details.",
+    SERVICE_ERROR: (error?: string) => error === undefined ? "Service error." : `Service Error: ${error}`,
+    UP_TO_DATE: "Your skill code is up to date with Alexa service."
+})


### PR DESCRIPTION

## Description
To consolidate hosted skill and self hosted skill deploy webviews messages in the constants file

## Motivation and Context
To consolidate the messages for better readability and easy to maintain.

## Testing
The skill deploy status overview table shows the expected messages.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License

- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
