### PR TITLE
fix: update postMessage args to get sign in flow working. fixes #124

### DIFF
--- a/media/initialLogin/initialLogin.html
+++ b/media/initialLogin/initialLogin.html
@@ -53,7 +53,7 @@
             const vscode = acquireVsCodeApi();
             window.onload = function(){
                 document.getElementById("signIn").onsubmit = function signIn() {
-                    vscode.postMessage();
+                    vscode.postMessage({});
                 };
             };
         </script>

--- a/src/askContainer/webViews/initialLogin.ts
+++ b/src/askContainer/webViews/initialLogin.ts
@@ -15,7 +15,7 @@ import { Logger } from '../../logger';
 
 
 type SignInType = {
-    profileName: string;
+    profileName?: string;
 };
 
 export class InitialLoginWebview extends AbstractWebView {


### PR DESCRIPTION
## Description
VSCode 1.56.x version breaks sign in flow, on clicking the `sign in` button which results in posting a message to the backend webview. During debugging, figured out that the login page [`onReceiveMessage` method](https://github.com/alexa/ask-toolkit-for-vscode/blob/development/src/askContainer/webViews/initialLogin.ts#L35) expects an argument while the frontend is sending in no arguments, as can be checked [here](https://github.com/alexa/ask-toolkit-for-vscode/blob/development/media/initialLogin/initialLogin.html#L56).

## Motivation and Context
Fixes #124 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested the flow to be working as expected on vscode 1.56.x. Also tested the change to be not breaking the experience in the earlier vscode version.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License

- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
