### PR TITLE
feat: set node.js 12 as default hosted skill node.js runtime version

### DIFF
--- a/media/createSkill/createSkill.html
+++ b/media/createSkill/createSkill.html
@@ -79,13 +79,13 @@
                                 <p class="details">Provision your own endpoint and backend resources for your skill. ASK Toolkit gets you started with a ”Hello world“ skill template, supports deploying a skill package but does not support it for your Lambda code.</p>
                             </div>
                         </div>
-                        
+
                         <div id="hostedCardsContainer" class="shown">
                             <br/><br/>
                             <label for="skillRuntime">Hosting runtime</label><br/>
                             <span>With Alexa-Hosted skills you get free hosting with AWS Lambda (up to the AWS Free Tier). <a href='https://developer.amazon.com/en-US/docs/alexa/hosted-skills/build-a-skill-end-to-end-using-an-alexa-hosted-skill.html'>Learn more</a></span>
                             <select id="runtime" name="runtime">
-                                <option value='NODE_10_X'>Alexa-Hosted (Node.js)</option>
+                                <option value='NODE_12_X'>Alexa-Hosted (Node.js)</option>
                                 <option value='PYTHON_3_7'>Alexa-Hosted (Python)</option>
                             </select>
                             <br/><br/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change allows the usage of Node.js 12 for Alexa Hosted Skills creation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][https://github.com/alexa/ask-toolkit-for-vscode/issues], please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This change has been tested.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License

- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
