### PR TITLE
feat: upgrade apl-suggester and apl-viewhost-web to version 1.8

### DIFF
--- a/media/previewApl/previewApl.html
+++ b/media/previewApl/previewApl.html
@@ -10,7 +10,7 @@
     content="default-src https: data:; img-src https: data:; script-src vscode-resource: https: data: 'unsafe-inline' 'unsafe-eval'; style-src vscode-resource: 'unsafe-inline';" />
     
     <title>APL Preview</title>
-    <script src="https://d2o906d8ln7ui1.cloudfront.net/apl-wasm-1.7.js"></script>
+    <script src="https://d2o906d8ln7ui1.cloudfront.net/apl-wasm-1.8.js"></script>
     <script>window.AplRenderer || document.write('<script src="${customJavascript}"><\\/script>')</script> 
     <script src="${aplRenderUtils}"></script>
     <script src="${javascript}"></script>

--- a/package.json
+++ b/package.json
@@ -346,8 +346,8 @@
   },
   "dependencies": {
     "adm-zip": "0.4.14",
-    "apl-suggester": "^1.7.0",
-    "apl-viewhost-web": "^1.7.0",
+    "apl-suggester": "^1.8.0",
+    "apl-viewhost-web": "^1.8.0",
     "ask-smapi-sdk": "^1.2.2",
     "async-retry": "^1.3.1",
     "axios": "^0.21.2",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Feature

- upgrade apl-suggester dependency from 1.7.0 to 1.8.0;
- upgrade apl-viewhost-web dependency from 1.7.0 to 1.8.0;
- update reference link of apl webview host from 1.7 to 1.8 in `previewApl.html`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

