### PR TITLE
feat: upgrade apl-suggester and apl-viewhost-web to version 1.9

### DIFF
--- a/media/previewApl/previewApl.html
+++ b/media/previewApl/previewApl.html
@@ -10,7 +10,7 @@
     content="default-src https: data:; img-src https: data:; script-src vscode-resource: https: data: 'unsafe-inline' 'unsafe-eval'; style-src vscode-resource: 'unsafe-inline';" />
     
     <title>APL Preview</title>
-    <script src="https://d2o906d8ln7ui1.cloudfront.net/apl-wasm-1.8.js"></script>
+    <script src="https://d2o906d8ln7ui1.cloudfront.net/apl-wasm-1.9.js"></script>
     <script>window.AplRenderer || document.write('<script src="${customJavascript}"><\\/script>')</script> 
     <script src="${aplRenderUtils}"></script>
     <script src="${javascript}"></script>

--- a/package.json
+++ b/package.json
@@ -346,8 +346,8 @@
   },
   "dependencies": {
     "adm-zip": "0.4.14",
-    "apl-suggester": "^1.8.0",
-    "apl-viewhost-web": "^1.8.0",
+    "apl-suggester": "^1.9.0",
+    "apl-viewhost-web": "^1.9.0",
     "ask-smapi-sdk": "^1.2.2",
     "async-retry": "^1.3.1",
     "axios": "^0.21.2",


### PR DESCRIPTION
Upgrade apl-suggester and apl-viewhost-web to version 1.9

## Description
Upgrade apl-suggester and apl-viewhost-web to version 1.9

## Testing
Test locally by running ```npm install``` and Run and Debug the extension for APL related features.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License

- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
