### PR TITLE
fix: revert pull request #164 causing authentication failures

### DIFF
--- a/src/runtime/lib/utils/lwa.ts
+++ b/src/runtime/lib/utils/lwa.ts
@@ -32,7 +32,7 @@ export async function accessTokenGenerator(lwaOptions: any): Promise<Token> {
 
   const OAuth: OAuthClient = createOAuth(clientId, clientSecret, lwaAuthorizeHost, lwaTokenHost);
   const SERVER_PORT = 9090;
-  const localServerUrl = `http://localhost:${SERVER_PORT}/cb`;
+  const localServerUrl = `http://127.0.0.1:${SERVER_PORT}/cb`;
   const authorizeUrl: string = OAuth.authorizationCode.authorizeURL({
     redirect_uri: localServerUrl,
     scope: scopes,

--- a/src/utils/captchaValidator.ts
+++ b/src/utils/captchaValidator.ts
@@ -30,7 +30,7 @@ async function _openLoginUrlWithRedirectLink(captchaUrl: string, vendorId: strin
     ["openid.claimed_id", "http://specs.openid.net/auth/2.0/identifier_select"],
     ["openid.identity", "http://specs.openid.net/auth/2.0/identifier_select"],
     ["openid.assoc_handle", "amzn_dante_us"],
-    ["openid.return_to", `${captchaUrl}?vendor_id=${vendorId}&redirect_url=http://localhost:${LOCALHOST_PORT}/captcha`],
+    ["openid.return_to", `${captchaUrl}?vendor_id=${vendorId}&redirect_url=http://127.0.0.1:${LOCALHOST_PORT}/captcha`],
     ["openid.pape.max_auth_age", "7200"],
   ]).toString();
   await open(loginUrl.href);


### PR DESCRIPTION
reverting PR that changed 127.0.0.1 usage to localhost

## Description


## Motivation and Context
These changes are causing an issue with LWA, preventing new users from logging into and using the extension. We are working on a permanent fix and intend to re-introduce the changes when the LWA configurations are updated and more thoroughly vetted.

Related issues:
https://github.com/alexa/ask-toolkit-for-vscode/issues/192
https://github.com/alexa/ask-toolkit-for-vscode/issues/191

## Testing

Manual testing against the LWA portal:

- Opened profile manager in the extension (3 small dots next to the Skills Management sidebar)
- Entered 'abc' in the Enter profile name under Create new profile, and hit Create
- Redirected to the browser, verified 127.0.0.1 is in the url rather than localhost, verified that login was successful

![image](https://user-images.githubusercontent.com/56455637/179294783-2cbfaa2e-b3f6-4660-810c-907244d79dcb.png)

Unit tests:
![image](https://user-images.githubusercontent.com/56455637/179295728-56d3adab-4584-4183-98ed-72b513c39718.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes -> Reverting code change, will add more tests when we re-introduce it
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License

- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
