### PR TITLE
chore: changing stale bot to 60 day stale time (from 14)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,10 +11,10 @@ jobs:
       - uses: actions/stale@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: "This issue is stale since it has been open for 14 days with no activity. Please respond or this issue will be closed soon."
+          stale-issue-message: "This issue is stale since it has been open for 60 days with no activity. Please respond or this issue will be closed soon."
           close-issue-message: "This stale issue has been closed now. Please reopen the issue if you are still having problems with the toolkit."
-          stale-pr-message: "This pr is stale since it has been open for 14 days with no activity. Please respond or this pr will be closed soon."
+          stale-pr-message: "This pr is stale since it has been open for 60 days with no activity. Please respond or this pr will be closed soon."
           stale-issue-label: "closing soon if no response"
           stale-pr-label: "no-pr-activity"
           exempt-issue-labels: "feature-request,waiting: external dependency,investigating,in progress,enhancement"
-          days-before-stale: 14
+          days-before-stale: 60


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changing stale time for stale bot to 60 days, up from 14.

## Motivation and Context
Legitimate issues are getting closed too quickly for inactivity.

## Testing
N/A, github configuration change

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License

- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
