### PR TITLE
fix: use localhost instead of 127.0.0.1 for LWA redirect

### DIFF
--- a/src/runtime/lib/utils/lwa.ts
+++ b/src/runtime/lib/utils/lwa.ts
@@ -32,7 +32,7 @@ export async function accessTokenGenerator(lwaOptions: any): Promise<Token> {
 
   const OAuth: OAuthClient = createOAuth(clientId, clientSecret, lwaAuthorizeHost, lwaTokenHost);
   const SERVER_PORT = 9090;
-  const localServerUrl = `http://127.0.0.1:${SERVER_PORT}/cb`;
+  const localServerUrl = `http://localhost:${SERVER_PORT}/cb`;
   const authorizeUrl: string = OAuth.authorizationCode.authorizeURL({
     redirect_uri: localServerUrl,
     scope: scopes,

--- a/src/utils/captchaValidator.ts
+++ b/src/utils/captchaValidator.ts
@@ -30,7 +30,7 @@ async function _openLoginUrlWithRedirectLink(captchaUrl: string, vendorId: strin
     ["openid.claimed_id", "http://specs.openid.net/auth/2.0/identifier_select"],
     ["openid.identity", "http://specs.openid.net/auth/2.0/identifier_select"],
     ["openid.assoc_handle", "amzn_dante_us"],
-    ["openid.return_to", `${captchaUrl}?vendor_id=${vendorId}&redirect_url=http://127.0.0.1:${LOCALHOST_PORT}/captcha`],
+    ["openid.return_to", `${captchaUrl}?vendor_id=${vendorId}&redirect_url=http://localhost:${LOCALHOST_PORT}/captcha`],
     ["openid.pape.max_auth_age", "7200"],
   ]).toString();
   await open(loginUrl.href);


### PR DESCRIPTION
Use localhost instead 127.0.0.1 for WSL support

<!--- Provide a general summary of your changes in the Title above -->

## Description
Re-introducing the changes to use localhost in the redirect URL for LWA authentication, rather than 127.0.0.1.

The changes were initially introduced [here](https://github.com/alexa/ask-toolkit-for-vscode/pull/164) and reverted [here](https://github.com/alexa/ask-toolkit-for-vscode/pull/193).

## Motivation and Context
This allows the redirect to go through successfully for WSL users.

For context, these changes were introduced in version 2.11.2 of the extension but were backed out, as it caused an issue for new profiles when attempting to authenticate. The redirect URL whitelist in the existing security profile was not configured to allow for localhost:9090. We have since updated the configuration and can move ahead with this change (testing details below). 

## Testing
Downgraded extension to 2.11.2, where the changes (and localhost redirect failure) were first introduced:
![image](https://user-images.githubusercontent.com/56455637/181349152-adcc3d55-d05c-4b53-8a4b-a5f1e73ab186.png)

Created a new profile:
![image](https://user-images.githubusercontent.com/56455637/181344516-38fa9f6b-e7a6-4541-a852-f5d5aee97425.png)

Signed in to the LWA portal, redirect URL is now showing localhost and is successful:
![image](https://user-images.githubusercontent.com/56455637/181348679-49285cdf-f162-45b4-90ba-e3a9699122ca.png)
![image](https://user-images.githubusercontent.com/56455637/181348703-8a909d4b-6df3-4d0b-8a11-a3c3083439e8.png)

We are also getting the success response in VSCode: 
![image](https://user-images.githubusercontent.com/56455637/181348757-e069a16b-8a56-4ee3-88f5-ad0fb442d68f.png)

Unit tests successful:
![image](https://user-images.githubusercontent.com/56455637/181349023-35c9f0f8-8034-4ad4-8588-bc7f0ccd3d4a.png)

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License

- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
