### PR TITLE
feat: setting Node.js 16 as default runtime for AlexaHosted Skills

### DIFF
--- a/media/createSkill/createSkill.html
+++ b/media/createSkill/createSkill.html
@@ -48,7 +48,7 @@
                         </select>
                         <br/><br/>
                         <label for="defaultLanguage">Skill Model</label><br/>
-                        <span>The extension will create a <a href="https://developer.amazon.com/en-US/docs/alexa/custom-skills/understanding-custom-skills.html">Custom Skill</a> containing a custom interaction model based on a Hello World sample project. From there you can design your own custom experience by defining the requests your skill can handle. 
+                        <span>The extension will create a <a href="https://developer.amazon.com/en-US/docs/alexa/custom-skills/understanding-custom-skills.html">Custom Skill</a> containing a custom interaction model based on a Hello World sample project. From there you can design your own custom experience by defining the requests your skill can handle.
                              </span>
                         <div class="provision-cards-container">
                             <div id="skillModelCard" class="skill-card">
@@ -68,7 +68,7 @@
                                     selected
                                 </div>
                                 <p class="title">Alexa-hosted</p>
-                                <p class="details">Alexa will host skills in your account up to the AWS Free Tier limits and get you started with a skill template. You will gain access to AWS Lambda endpoints in all Alexa service regions, a DynamoDB table for data persistence, and S3 for media storage. 
+                                <p class="details">Alexa will host skills in your account up to the AWS Free Tier limits and get you started with a skill template. You will gain access to AWS Lambda endpoints in all Alexa service regions, a DynamoDB table for data persistence, and S3 for media storage.
                                     <a href="https://developer.amazon.com/en-US/docs/alexa/hosted-skills/build-a-skill-end-to-end-using-an-alexa-hosted-skill.html">Learn more</a></p>
                             </div>
                             <div id="provisionOwnCard" class="skill-card">
@@ -85,7 +85,7 @@
                             <label for="skillRuntime">Hosting runtime</label><br/>
                             <span>With Alexa-Hosted skills you get free hosting with AWS Lambda (up to the AWS Free Tier). <a href='https://developer.amazon.com/en-US/docs/alexa/hosted-skills/build-a-skill-end-to-end-using-an-alexa-hosted-skill.html'>Learn more</a></span>
                             <select id="runtime" name="runtime">
-                                <option value='NODE_12_X'>Alexa-Hosted (Node.js)</option>
+                                <option value='NODE_16_X'>Alexa-Hosted (Node.js)</option>
                                 <option value='PYTHON_3_7'>Alexa-Hosted (Python)</option>
                             </select>
                             <br/><br/>
@@ -97,7 +97,7 @@
                                 <option value='US_WEST_2'>US West (Oregon)</option>
                             </select>
                         </div>
-                        
+
                         <div id="selfHostedContainer" class="hidden">
                             <br/><br/>
                             <label for="skillRuntime">Programming language</label><br/>
@@ -108,7 +108,7 @@
                                 <option value='Java'>Java</option>
                             </select>
                         </div>
-                        
+
 
                         <br/><br/>
                         <label for="skillFolder">Local directory</label><br/>


### PR DESCRIPTION
## Description
This change is to update Alexa Hosted Skills node runtime to Node.js 16.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License

- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
