### PR TITLE
fix: rolling back VSCode version for testing to 1.72.2

### DIFF
--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -25,6 +25,9 @@ async function main() {
       extensionDevelopmentPath,
       extensionTestsPath,
       launchArgs: ["--disable-extensions"],
+      //TODO: Delete this to use the latest VSCode version.
+      //Some change made in the 1.73.1 release broke WebView loading behavior in our tests
+      version: "1.72.2",
     });
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
VSCode update in 1.73.1 broke some of the WebView loading behavior in our test utilities, rolling back for 1.72.2 temporarily until the root cause is resolved.

## Testing
All unit tests pass.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
- [X] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License

- [ ] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
