### PR TITLE
fix: correct AbstractCommand for context menus

### DIFF
--- a/src/runtime/lib/API.ts
+++ b/src/runtime/lib/API.ts
@@ -76,7 +76,7 @@ export abstract class AbstractCommand<T> implements GenericCommand, Command {
   }
 
   private async _invoke(commandName: string, ...args: any[]): Promise<T> {
-    const typeArg = args.find((arg) => arg.CommandType);
+    const typeArg = args.find((arg) => arg && arg.CommandType);
     const commandType = typeArg !== undefined ? typeArg.CommandType : ActionType.COMMAND;
     let output: any;
 

--- a/src/runtime/lib/API.ts
+++ b/src/runtime/lib/API.ts
@@ -76,7 +76,7 @@ export abstract class AbstractCommand<T> implements GenericCommand, Command {
   }
 
   private async _invoke(commandName: string, ...args: any[]): Promise<T> {
-    const typeArg = args.find((arg) => arg && arg.CommandType);
+    const typeArg = args.find((arg) => arg?.CommandType);
     const commandType = typeArg !== undefined ? typeArg.CommandType : ActionType.COMMAND;
     let output: any;
 

--- a/test/askContainer/commands/deviceRegistry.test.ts
+++ b/test/askContainer/commands/deviceRegistry.test.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Alexa Skills Toolkit for Visual Studio Code
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *--------------------------------------------------------------------------------------------*/
+import * as vscode from "vscode";
+import * as assert from "assert";
+import * as sinon from "sinon";
+
+import {DeviceRegistryCommand} from "../../../src/askContainer/commands/deviceRegistryCommand";
+import {stubTelemetryClient} from "../../../test/testUtilities";
+
+describe("Command askContainer.skillsConsole.deviceRegistry", () => {
+  let command: DeviceRegistryCommand;
+  let sandbox: sinon.SinonSandbox;
+
+  after(() => {
+    command.dispose();
+  });
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    stubTelemetryClient(sandbox);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("Should show the view when executed", async () => {
+    const showViewSpy = sinon.spy();
+    command = new DeviceRegistryCommand({showView: showViewSpy} as any);
+
+    /*
+        undefined argument due to
+
+        https://code.visualstudio.com/api/references/contribution-points#contributes.menus
+        Note: When a command is invoked from a (context) menu, VS Code tries to infer the currently selected resource 
+        and passes that as a parameter when invoking the command. 
+
+    */
+    await vscode.commands.executeCommand("askContainer.skillsConsole.deviceRegistry", undefined);
+
+    assert.ok(showViewSpy.called);
+  });
+});


### PR DESCRIPTION
## Description
Context menu commands do not work.


## Motivation and Context
fixes #227 that has been bizarrely closed in favour of a workaround.

## Testing
https://github.com/tonyhallett/ask-toolkit-for-vscode/blob/fix-closed-issue-227/test/askContainer/commands/deviceRegistry.test.ts

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License

- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
