### PR TITLE
feat: upgrade apl-suggester and apl-viewhost-web to version 2023.1

### DIFF
--- a/media/previewApl/previewApl.html
+++ b/media/previewApl/previewApl.html
@@ -10,7 +10,7 @@
     content="default-src https: data:; img-src https: data:; script-src vscode-resource: https: data: 'unsafe-inline' 'unsafe-eval'; style-src vscode-resource: 'unsafe-inline';" />
     
     <title>APL Preview</title>
-    <script src="https://d2o906d8ln7ui1.cloudfront.net/apl-wasm-2022.2.js"></script>
+    <script src="https://d2o906d8ln7ui1.cloudfront.net/apl-wasm-2023.1.js"></script>
     <script>window.AplRenderer || document.write('<script src="${customJavascript}"><\\/script>')</script> 
     <script src="${aplRenderUtils}"></script>
     <script src="${javascript}"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "adm-zip": "0.4.14",
-        "apl-suggester": "^2022.2.0",
-        "apl-viewhost-web": "^2022.2.0",
+        "apl-suggester": "^2023.1.0",
+        "apl-viewhost-web": "^2023.1.0-1",
         "ask-smapi-sdk": "^1.2.2",
         "async-retry": "^1.3.1",
         "axios": "^0.21.2",
@@ -1511,14 +1511,18 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+      "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
       "dependencies": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ajv-keywords": {
@@ -1606,20 +1610,21 @@
       }
     },
     "node_modules/apl-suggester": {
-      "version": "2022.2.0",
-      "resolved": "https://registry.npmjs.org/apl-suggester/-/apl-suggester-2022.2.0.tgz",
-      "integrity": "sha512-bJhDMrIxHYfb3jOuKaX9NprZRfpVakE6CuYKbhy2mOCipZw0Rf4B4UAy9seQ5u7w+E0Az6rjTWhnFJT/QuMaiQ==",
+      "version": "2023.1.0",
+      "resolved": "https://registry.npmjs.org/apl-suggester/-/apl-suggester-2023.1.0.tgz",
+      "integrity": "sha512-f8sZk8CD7UCKAgkw+/Fab8a3EBvdA0G9/uvqUldb/YbeA5eNNcj6HQIgYxMd6bfo/a2PywumuQg4pngncuKCgw==",
       "dependencies": {
         "@types/chai": "3.5.x",
         "@types/core-js": "2.5.x",
         "@types/node": "12.0.x",
         "@types/sinon": "2.2.x",
-        "ajv": "6.10.x",
-        "axios": ">=0.21.1",
-        "immutable": ">4.0.0-rc",
+        "ajv": "6.12.3",
+        "axios": "0.27.2",
+        "immutable": "4.1.0",
         "jsdom-global": "3.0.x",
         "ts-node": "3.3.x",
-        "typescript": "3.x"
+        "typescript": "3.x",
+        "user": "^0.0.0"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -1634,6 +1639,28 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-2.2.2.tgz",
       "integrity": "sha1-qA2khougisysvOTTcnbzXhugpS8="
+    },
+    "node_modules/apl-suggester/node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/apl-suggester/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/apl-suggester/node_modules/ts-node": {
       "version": "3.3.0",
@@ -1660,9 +1687,9 @@
       }
     },
     "node_modules/apl-viewhost-web": {
-      "version": "2022.2.0",
-      "resolved": "https://registry.npmjs.org/apl-viewhost-web/-/apl-viewhost-web-2022.2.0.tgz",
-      "integrity": "sha512-udpNOkL4M9L68c0MnW6HyHvTJfbCIjSE83AYtfo34J3DoaJsJe5JdOoc6jTDA5L/Mfx5/ZdEBv/8ZFGAfNpljw==",
+      "version": "2023.1.0-1",
+      "resolved": "https://registry.npmjs.org/apl-viewhost-web/-/apl-viewhost-web-2023.1.0-1.tgz",
+      "integrity": "sha512-FO0aRTP9S+7BtxX3hezqq/UIswngrAo5D3gATZujHRpjkV2U7lCZlovAs/d+79yq2F14Nny43Pm3peWpHP1/ow==",
       "hasInstallScript": true
     },
     "node_modules/append-buffer": {
@@ -4534,9 +4561,9 @@
       }
     },
     "node_modules/fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -5834,11 +5861,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/har-validator/node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-    },
     "node_modules/hard-rejection": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
@@ -6316,9 +6338,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.0.0-rc.14",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0-rc.14.tgz",
-      "integrity": "sha512-pfkvmRKJSoW7JFx0QeYlAmT+kNYvn5j0u7bnpNq4N2RCvHSTlLT208G8jgaquNe+Q8kCPHKOSpxJkyvLDpYq0w=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -10482,12 +10504,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/schema-utils/node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
-    },
     "node_modules/semver": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
@@ -12545,6 +12561,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/user": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/user/-/user-0.0.0.tgz",
+      "integrity": "sha512-eRNM5isOvr6aEFAGi1CqAkmLkYxW2NJ5ThhbD+6IJXYKM1mo7Gtxx4mQIveHz/5K3p/SVnlW9k17ETn+QAu8IQ=="
+    },
     "node_modules/utf-8-validate": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.5.tgz",
@@ -14563,11 +14584,11 @@
       }
     },
     "ajv": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+      "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
@@ -14640,20 +14661,21 @@
       }
     },
     "apl-suggester": {
-      "version": "2022.2.0",
-      "resolved": "https://registry.npmjs.org/apl-suggester/-/apl-suggester-2022.2.0.tgz",
-      "integrity": "sha512-bJhDMrIxHYfb3jOuKaX9NprZRfpVakE6CuYKbhy2mOCipZw0Rf4B4UAy9seQ5u7w+E0Az6rjTWhnFJT/QuMaiQ==",
+      "version": "2023.1.0",
+      "resolved": "https://registry.npmjs.org/apl-suggester/-/apl-suggester-2023.1.0.tgz",
+      "integrity": "sha512-f8sZk8CD7UCKAgkw+/Fab8a3EBvdA0G9/uvqUldb/YbeA5eNNcj6HQIgYxMd6bfo/a2PywumuQg4pngncuKCgw==",
       "requires": {
         "@types/chai": "3.5.x",
         "@types/core-js": "2.5.x",
         "@types/node": "12.0.x",
         "@types/sinon": "2.2.x",
-        "ajv": "6.10.x",
-        "axios": ">=0.21.1",
-        "immutable": ">4.0.0-rc",
+        "ajv": "6.12.3",
+        "axios": "0.27.2",
+        "immutable": "4.1.0",
         "jsdom-global": "3.0.x",
         "ts-node": "3.3.x",
-        "typescript": "3.x"
+        "typescript": "3.x",
+        "user": "^0.0.0"
       },
       "dependencies": {
         "@types/node": {
@@ -14665,6 +14687,25 @@
           "version": "2.2.2",
           "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-2.2.2.tgz",
           "integrity": "sha1-qA2khougisysvOTTcnbzXhugpS8="
+        },
+        "axios": {
+          "version": "0.27.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+          "requires": {
+            "follow-redirects": "^1.14.9",
+            "form-data": "^4.0.0"
+          }
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
         },
         "ts-node": {
           "version": "3.3.0",
@@ -14686,9 +14727,9 @@
       }
     },
     "apl-viewhost-web": {
-      "version": "2022.2.0",
-      "resolved": "https://registry.npmjs.org/apl-viewhost-web/-/apl-viewhost-web-2022.2.0.tgz",
-      "integrity": "sha512-udpNOkL4M9L68c0MnW6HyHvTJfbCIjSE83AYtfo34J3DoaJsJe5JdOoc6jTDA5L/Mfx5/ZdEBv/8ZFGAfNpljw=="
+      "version": "2023.1.0-1",
+      "resolved": "https://registry.npmjs.org/apl-viewhost-web/-/apl-viewhost-web-2023.1.0-1.tgz",
+      "integrity": "sha512-FO0aRTP9S+7BtxX3hezqq/UIswngrAo5D3gATZujHRpjkV2U7lCZlovAs/d+79yq2F14Nny43Pm3peWpHP1/ow=="
     },
     "append-buffer": {
       "version": "1.0.2",
@@ -16949,9 +16990,9 @@
       }
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -17957,11 +17998,6 @@
             "json-schema-traverse": "^0.4.1",
             "uri-js": "^4.2.2"
           }
-        },
-        "fast-deep-equal": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         }
       }
     },
@@ -18294,9 +18330,9 @@
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
     },
     "immutable": {
-      "version": "4.0.0-rc.14",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0-rc.14.tgz",
-      "integrity": "sha512-pfkvmRKJSoW7JFx0QeYlAmT+kNYvn5j0u7bnpNq4N2RCvHSTlLT208G8jgaquNe+Q8kCPHKOSpxJkyvLDpYq0w=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -21482,12 +21518,6 @@
             "json-schema-traverse": "^0.4.1",
             "uri-js": "^4.2.2"
           }
-        },
-        "fast-deep-equal": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-          "dev": true
         }
       }
     },
@@ -23115,6 +23145,11 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "user": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/user/-/user-0.0.0.tgz",
+      "integrity": "sha512-eRNM5isOvr6aEFAGi1CqAkmLkYxW2NJ5ThhbD+6IJXYKM1mo7Gtxx4mQIveHz/5K3p/SVnlW9k17ETn+QAu8IQ=="
     },
     "utf-8-validate": {
       "version": "5.0.5",

--- a/package.json
+++ b/package.json
@@ -346,8 +346,8 @@
   },
   "dependencies": {
     "adm-zip": "0.4.14",
-    "apl-suggester": "^2022.2.0",
-    "apl-viewhost-web": "^2022.2.0",
+    "apl-suggester": "^2023.1.0",
+    "apl-viewhost-web": "^2023.1.0-1",
     "ask-smapi-sdk": "^1.2.2",
     "async-retry": "^1.3.1",
     "axios": "^0.21.2",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Upgrade apl-suggester and apl-viewhost-web to version 2023.1

## Motivation and Context
This PR updates VS Code Extension to use the latest version of suggester and viewhost.

## Testing
Test locally by running npm i and then running and debugging the extension for APL related features.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License

- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
