### PR TITLE
fix: skill creation and clone returns 'no skill repository found'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "alexa-skills-kit-toolkit",
-      "version": "2.12.1",
+      "version": "2.14.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@alexa/acdl": "0.3.0",
+        "@alexa/acdl": "*",
         "adm-zip": "0.4.14",
         "apl-suggester": "^2023.1.0",
         "apl-viewhost-web": "^2023.1.0-1",

--- a/package.json
+++ b/package.json
@@ -366,7 +366,7 @@
     "webpack-cli": "^4.5.0"
   },
   "dependencies": {
-    "@alexa/acdl": "0.3.0",
+    "@alexa/acdl": "*",
     "adm-zip": "0.4.14",
     "apl-suggester": "^2023.1.0",
     "apl-viewhost-web": "^2023.1.0-1",

--- a/src/utils/cloneSkillHelper.ts
+++ b/src/utils/cloneSkillHelper.ts
@@ -22,141 +22,11 @@ import {AskError, logAskError} from "../exceptions";
 import {Logger} from "../logger";
 import {SkillInfo} from "../models/types";
 import {CommandContext, SmapiClientFactory, SmapiResource, Utils} from "../runtime";
-import {getSkillNameFromLocales} from "../utils/skillHelper";
-import {openWorkspaceFolder} from "../utils/workspaceHelper";
-import {getOrInstantiateGitApi, GitInTerminalHelper, isGitInstalled} from "./gitHelper";
+import {getSkillNameFromLocales} from "./skillHelper";
+import {openWorkspaceFolder} from "./workspaceHelper";
+import {GitInTerminalHelper, isGitInstalled} from "./gitHelper";
 import {checkAskPrePushScript, checkAuthInfoScript, checkGitCredentialHelperScript} from "./s3ScriptChecker";
 import {createSkillPackageFolder, syncSkillPackage} from "./skillPackageHelper";
-
-export async function executeClone(context: CommandContext, skillInfo: SmapiResource<SkillInfo>) {
-  try {
-    const skillFolderUri = await createSkillFolder(skillInfo);
-    if (skillFolderUri === undefined) {
-      return;
-    }
-    // Create progress bar and run next steps
-    await vscode.window.withProgress(
-      {
-        location: vscode.ProgressLocation.Notification,
-        title: "Downloading skill",
-        cancellable: false,
-      },
-      async (progress, token) => {
-        await cloneSkill(skillInfo, skillFolderUri.fsPath, context.extensionContext, progress);
-      },
-    );
-    const skillName = getSkillNameFromLocales(skillInfo.data.skillSummary.nameByLocale!);
-    const cloneSkillMsg = `Skill ${skillName} was cloned successfully and added to workspace. The skill is located at ${skillFolderUri.fsPath}`;
-
-    Logger.info(cloneSkillMsg);
-    vscode.window.showInformationMessage(cloneSkillMsg);
-
-    // Add skill folder to workspace
-    await openWorkspaceFolder(skillFolderUri);
-    return;
-  } catch (err) {
-    throw logAskError(`Skill clone failed`, err, true);
-  }
-}
-
-async function createSkillFolder(skillInfo: SmapiResource<SkillInfo>): Promise<vscode.Uri | undefined> {
-  Logger.verbose(`Calling method: createSkillFolder, args: `, skillInfo);
-  const selectedFolderArray = await vscode.window.showOpenDialog({
-    openLabel: "Select project folder",
-    canSelectFiles: false,
-    canSelectFolders: true,
-    canSelectMany: false,
-  });
-  if (selectedFolderArray === undefined) {
-    return undefined;
-  }
-
-  const projectFolder = selectedFolderArray[0];
-  const skillName = getSkillNameFromLocales(skillInfo.data.skillSummary.nameByLocale!);
-  const filteredProjectName = Utils.filterNonAlphanumeric(skillName);
-  const skillFolderAbsPath = path.join(projectFolder.fsPath, filteredProjectName);
-
-  // create skill folder in project path
-  if (fs.existsSync(skillFolderAbsPath)) {
-    Logger.debug(`Skill folder ${skillFolderAbsPath} already exists.`);
-    const errorMessage = `Skill folder ${skillFolderAbsPath} already exists. Would you like to overwrite it?`;
-    const overWriteSelection = await vscode.window.showInformationMessage(errorMessage, ...["Yes", "No"]);
-    if (overWriteSelection === "Yes") {
-      Logger.debug(`Confirmed skill folder overwrite option. Overwriting ${skillFolderAbsPath}.`);
-      fsExtra.removeSync(skillFolderAbsPath);
-    } else {
-      return undefined;
-    }
-  }
-
-  fs.mkdirSync(skillFolderAbsPath);
-
-  return vscode.Uri.file(skillFolderAbsPath);
-}
-
-async function setupGitFolder(skillInfo: SmapiResource<SkillInfo>, targetPath: string, context: vscode.ExtensionContext): Promise<void> {
-  try {
-    Logger.verbose(`Calling method: setupGitFolder, args: `, skillInfo, targetPath);
-    let profile = Utils.getCachedProfile(context);
-    profile = profile ?? DEFAULT_PROFILE;
-    const smapiClient = SmapiClientFactory.getInstance(profile, context);
-    const skillId = skillInfo.data.skillSummary.skillId!;
-
-    const credentialsList = await smapiClient.generateCredentialsForAlexaHostedSkillV1(skillId, {
-      repository: skillInfo.data.hostedSkillMetadata?.alexaHosted?.repository!,
-    });
-    const repositoryCredentials = credentialsList.repositoryCredentials;
-    if (!repositoryCredentials || !repositoryCredentials.username || !repositoryCredentials.password) {
-      throw new Error("Failed to retrieve hosted skill credentials from the service.");
-    }
-    const gitHelper = new GitInTerminalHelper(targetPath, Logger.logLevel);
-    const repoUrl = skillInfo.data.hostedSkillMetadata?.alexaHosted?.repository?.url;
-    if (!repoUrl) {
-      throw new Error("Failed to retrieve hosted skill repo URL from the service.");
-    }
-    await downloadGitCredentialScript(targetPath, context);
-    gitHelper.init();
-    gitHelper.configureCredentialHelper(repoUrl, profile, skillId);
-    gitHelper.addOrigin(repoUrl);
-
-    /**
-     * Since gitHelper commands are failing due to execSync
-     * not waiting to call next command, calling the following
-     * set of git commands through inbuilt git extension
-     */
-    await vscode.commands.executeCommand("git.openRepository", targetPath);
-
-    const gitApi = await getOrInstantiateGitApi(context);
-    const repo = gitApi?.getRepository(vscode.Uri.file(targetPath));
-
-    await repo?.fetch();
-    await repo?.checkout("prod");
-    await repo?.checkout("master");
-    await setPrePushHookScript(targetPath, context);
-  } catch (err) {
-    throw logAskError(`Git folder setup failed for ${targetPath}`, err);
-  }
-}
-
-function createAskResourcesConfig(projectPath: string, profile: string | undefined, skillId: string): void {
-  Logger.verbose(`Calling method: createAskResourcesConfig, args: `, projectPath, profile, skillId);
-  profile = profile ?? DEFAULT_PROFILE;
-  const askResourcesPath = path.join(projectPath, SKILL_FOLDER.ASK_RESOURCES_JSON_CONFIG);
-
-  let askResourcesJson = R.clone(BASE_RESOURCES_CONFIG);
-  askResourcesJson = R.set(R.lensPath(["profiles", profile, "skillId"]), skillId, askResourcesJson);
-  askResourcesJson = R.set(R.lensPath(["profiles", profile, "skillInfrastructure", "type"]), CLI_HOSTED_SKILL_TYPE, askResourcesJson);
-  fs.writeFileSync(askResourcesPath, JSON.stringify(askResourcesJson, null, 2));
-}
-
-function createAskStateConfig(projectPath: string, profile: string, skillId: string): void {
-  Logger.verbose(`Calling method: createAskStateConfig, args: `, projectPath, profile, skillId);
-  const askStatesPath = path.join(projectPath, SKILL_FOLDER.HIDDEN_ASK_FOLDER, SKILL_FOLDER.ASK_STATES_JSON_CONFIG);
-
-  let askStatesJson = R.clone(BASE_STATES_CONFIG);
-  askStatesJson = R.set(R.lensPath(["profiles", profile, "skillId"]), skillId, askStatesJson);
-  fs.writeFileSync(askStatesPath, JSON.stringify(askStatesJson, null, 2));
-}
 
 function downloadScriptFile(scriptUrl: string, filePath: string, chmod: string): Promise<void> {
   Logger.verbose(`Calling method: downloadScriptFile, args: `, scriptUrl, filePath, chmod);
@@ -197,11 +67,82 @@ async function downloadGitCredentialScript(projectPath: string, context: vscode.
   await checkGitCredentialHelperScript(context);
 }
 
+async function setupGitFolder(skillInfo: SmapiResource<SkillInfo>, targetPath: string, context: vscode.ExtensionContext): Promise<void> {
+  try {
+    Logger.verbose(`Calling method: setupGitFolder, args: `, skillInfo, targetPath);
+    let profile = Utils.getCachedProfile(context);
+    profile = profile ?? DEFAULT_PROFILE;
+    const smapiClient = SmapiClientFactory.getInstance(profile, context);
+    const skillId = skillInfo.data.skillSummary.skillId!;
+
+    const credentialsList = await smapiClient.generateCredentialsForAlexaHostedSkillV1(skillId, {
+      repository: skillInfo.data.hostedSkillMetadata?.alexaHosted?.repository!,
+    });
+    const {repositoryCredentials} = credentialsList;
+    if (!repositoryCredentials || !repositoryCredentials.username || !repositoryCredentials.password) {
+      throw new Error("Failed to retrieve hosted skill credentials from the service.");
+    }
+    const gitHelper = new GitInTerminalHelper(targetPath, Logger.logLevel);
+    const repoUrl = skillInfo.data.hostedSkillMetadata?.alexaHosted?.repository?.url;
+    if (!repoUrl) {
+      throw new Error("Failed to retrieve hosted skill repo URL from the service.");
+    }
+    await downloadGitCredentialScript(targetPath, context);
+
+    gitHelper.init();
+    gitHelper.configureCredentialHelper(repoUrl, profile, skillId);
+    gitHelper.addOrigin(repoUrl);
+
+    /**
+     * Since gitHelper commands are failing due to execSync
+     * not waiting to call next command, calling the following
+     * set of git commands through inbuilt git extension
+     */
+    await vscode.commands.executeCommand("git.openRepository", targetPath);
+
+    gitHelper.fetchAll();
+    gitHelper.checkoutBranch("prod");
+    gitHelper.checkoutBranch("master");
+    await setPrePushHookScript(targetPath, context);
+  } catch (err) {
+    throw logAskError(`Git folder setup failed for ${targetPath}`, err);
+  }
+}
+
+function createAskResourcesConfig(projectPath: string, profile: string | undefined, skillId: string): void {
+  Logger.verbose(`Calling method: createAskResourcesConfig, args: `, projectPath, profile, skillId);
+  const currentProfile = profile ?? DEFAULT_PROFILE;
+  const askResourcesPath = path.join(projectPath, SKILL_FOLDER.ASK_RESOURCES_JSON_CONFIG);
+
+  let askResourcesJson = R.clone(BASE_RESOURCES_CONFIG);
+  askResourcesJson = R.set(R.lensPath(["profiles", currentProfile, "skillId"]), skillId, askResourcesJson);
+  askResourcesJson = R.set(
+    R.lensPath(["profiles", currentProfile, "skillInfrastructure", "type"]),
+    CLI_HOSTED_SKILL_TYPE,
+    askResourcesJson,
+  );
+  fs.writeFileSync(askResourcesPath, JSON.stringify(askResourcesJson, null, 2));
+}
+
+function createAskStateConfig(projectPath: string, profile: string, skillId: string): void {
+  Logger.verbose(`Calling method: createAskStateConfig, args: `, projectPath, profile, skillId);
+  const askStatesPath = path.join(projectPath, SKILL_FOLDER.HIDDEN_ASK_FOLDER, SKILL_FOLDER.ASK_STATES_JSON_CONFIG);
+
+  let askStatesJson = R.clone(BASE_STATES_CONFIG);
+  askStatesJson = R.set(R.lensPath(["profiles", profile, "skillId"]), skillId, askStatesJson);
+  fs.writeFileSync(askStatesPath, JSON.stringify(askStatesJson, null, 2));
+}
+
 function checkGitInstallation() {
   Logger.verbose(`Calling method: checkGitInstallation`);
   if (!isGitInstalled()) {
     throw new AskError(GIT_MESSAGES.GIT_NOT_FOUND);
   }
+}
+
+function filesToIgnore(): string[] {
+  const nodeModules = `${SKILL_FOLDER.LAMBDA.NAME}/${SKILL_FOLDER.LAMBDA.NODE_MODULES}`;
+  return [SKILL_FOLDER.ASK_RESOURCES_JSON_CONFIG, SKILL_FOLDER.HIDDEN_ASK_FOLDER, SKILL_FOLDER.HIDDEN_VSCODE, nodeModules, ".DS_Store"];
 }
 
 export async function cloneSkill(
@@ -256,7 +197,68 @@ export async function cloneSkill(
   }
 }
 
-function filesToIgnore(): string[] {
-  const nodeModules = `${SKILL_FOLDER.LAMBDA.NAME}/${SKILL_FOLDER.LAMBDA.NODE_MODULES}`;
-  return [SKILL_FOLDER.ASK_RESOURCES_JSON_CONFIG, SKILL_FOLDER.HIDDEN_ASK_FOLDER, SKILL_FOLDER.HIDDEN_VSCODE, nodeModules, ".DS_Store"];
+async function createSkillFolder(skillInfo: SmapiResource<SkillInfo>): Promise<vscode.Uri | undefined> {
+  Logger.verbose(`Calling method: createSkillFolder, args: `, skillInfo);
+  const selectedFolderArray = await vscode.window.showOpenDialog({
+    openLabel: "Select project folder",
+    canSelectFiles: false,
+    canSelectFolders: true,
+    canSelectMany: false,
+  });
+  if (selectedFolderArray === undefined) {
+    return undefined;
+  }
+
+  const projectFolder = selectedFolderArray[0];
+  const skillName = getSkillNameFromLocales(skillInfo.data.skillSummary.nameByLocale!);
+  const filteredProjectName = Utils.filterNonAlphanumeric(skillName);
+  const skillFolderAbsPath = path.join(projectFolder.fsPath, filteredProjectName);
+
+  // create skill folder in project path
+  if (fs.existsSync(skillFolderAbsPath)) {
+    Logger.debug(`Skill folder ${skillFolderAbsPath} already exists.`);
+    const errorMessage = `Skill folder ${skillFolderAbsPath} already exists. Would you like to overwrite it?`;
+    const overWriteSelection = await vscode.window.showInformationMessage(errorMessage, ...["Yes", "No"]);
+    if (overWriteSelection === "Yes") {
+      Logger.debug(`Confirmed skill folder overwrite option. Overwriting ${skillFolderAbsPath}.`);
+      fsExtra.removeSync(skillFolderAbsPath);
+    } else {
+      return undefined;
+    }
+  }
+
+  fs.mkdirSync(skillFolderAbsPath);
+
+  return vscode.Uri.file(skillFolderAbsPath);
+}
+
+export async function executeClone(context: CommandContext, skillInfo: SmapiResource<SkillInfo>) {
+  try {
+    const skillFolderUri = await createSkillFolder(skillInfo);
+    if (skillFolderUri === undefined) {
+      return;
+    }
+    // Create progress bar and run next steps
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: "Downloading skill",
+        cancellable: false,
+      },
+      async (progress) => {
+        await cloneSkill(skillInfo, skillFolderUri.fsPath, context.extensionContext, progress);
+      },
+    );
+    const skillName = getSkillNameFromLocales(skillInfo.data.skillSummary.nameByLocale!);
+    const cloneSkillMsg = `Skill ${skillName} was cloned successfully and added to workspace. The skill is located at ${skillFolderUri.fsPath}`;
+
+    Logger.info(cloneSkillMsg);
+    vscode.window.showInformationMessage(cloneSkillMsg);
+
+    // Add skill folder to workspace
+    await openWorkspaceFolder(skillFolderUri);
+    return;
+  } catch (err) {
+    throw logAskError(`Skill clone failed`, err, true);
+  }
 }

--- a/src/utils/gitHelper.ts
+++ b/src/utils/gitHelper.ts
@@ -14,7 +14,8 @@ import {AskError} from "../exceptions";
 import {Logger, LogLevel} from "../logger";
 
 export class GitInTerminalHelper {
-  private folderPath: string;
+  public folderPath: string;
+
   private logLevel: LogLevel;
 
   constructor(folderPath: string, logLevel: LogLevel) {
@@ -76,7 +77,7 @@ export class GitInTerminalHelper {
   }
 
   checkoutBranch(branch: string): void {
-    const commands = [`git checkout ${branch} --quiet'}`];
+    const commands = [`git checkout ${branch} --quiet`];
     const options = {
       showOutput: this.logLevel === LogLevel.verbose,
       showStdErr: true,
@@ -109,6 +110,21 @@ export class GitInTerminalHelper {
     this._execChildProcessSync(command, options).toString();
   }
 
+  getCurrentBranch(): string {
+    const command = `git branch --show-current`;
+    const options = {
+      showStdErr: true,
+      showCommand: this.logLevel === LogLevel.verbose,
+      workingDir: this.folderPath,
+    };
+    try {
+      return this._execChildProcessSync(command, options).toString().trim();
+    } catch (error) {
+      Logger.error(`${error}`);
+      throw error;
+    }
+  }
+
   static addFilesToIgnore(targetPath: string, fileNames: string[]): void {
     Logger.verbose(`Calling method: addFilesToIgnore, args: `, targetPath, fileNames);
     const gitignorePath = path.join(targetPath, ".gitignore");
@@ -137,7 +153,7 @@ export class GitInTerminalHelper {
     }
   }
 
-  private _execChildProcessSync(command: string, options: any): Buffer {
+  public _execChildProcessSync(command: string, options: any): Buffer {
     const {showOutput, showStdErr, showCommand, workingDir} = options;
     const execOptions: ExecSyncOptions = {
       stdio: [null, showOutput === true ? 1 : null, showStdErr === true ? 2 : null],

--- a/test/utils/gitHelper.test.ts
+++ b/test/utils/gitHelper.test.ts
@@ -1,0 +1,57 @@
+import {existsSync, mkdirSync} from "fs";
+import {removeSync} from "fs-extra";
+import * as assert from "assert";
+import os from "os";
+import * as fs from "fs";
+import sinon from "sinon";
+import * as path from "path";
+import {LogLevel} from "../../src/logger";
+import {GitInTerminalHelper} from "../../src/utils/gitHelper";
+import {SYSTEM_ASK_FOLDER} from "../../src/constants";
+
+describe("GitInTerminalHelper tests", () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("init", () => {
+    const tmpDir = os.tmpdir();
+    const emptyDir = `${tmpDir}/gitHelperTest`;
+    beforeEach(() => {
+      if (!existsSync(emptyDir)) {
+        mkdirSync(emptyDir);
+      }
+    });
+
+    afterEach(() => {
+      if (existsSync(emptyDir)) {
+        removeSync(emptyDir);
+      }
+    });
+
+    it("creates a .git subfolder when initializing a new repository", () => {
+      const helper = new GitInTerminalHelper(emptyDir, LogLevel.off);
+      helper.init();
+      assert.strictEqual(existsSync(`${emptyDir}/.git`), true);
+    });
+  });
+
+  describe("getCurrentBranch", () => {
+    it("returns the branch 'master'", () => {
+      const helper = new GitInTerminalHelper("mockRepo", LogLevel.off);
+      sandbox.stub(helper, "_execChildProcessSync").returns("master");
+      const currentBranch = helper.getCurrentBranch();
+      assert.strictEqual(
+        currentBranch,
+        "master",
+        `Current branch not equal to master. Current branch: ${currentBranch}\nRepository location: ${helper.folderPath}`,
+      );
+    });
+  });
+});


### PR DESCRIPTION
Fixes #234 

## Description
The built-in vscode APIs for git management are failing to retrieve repositories in our environment, so for now we will fall back to executing git via the shell (some operations were already running through the shell). 

Adds a `getCurrentBranch` operation to the git terminal helper to facilitate the transition.

Also contains some ESLint corrections in the file `src/utils/cloneSkillHelper.ts`, mostly around usage before declaration.

## Testing
Manually tested, as well as added a unit tests around git helper functions:
<img width="740" alt="image" src="https://user-images.githubusercontent.com/56455637/229925569-5d58f3f1-aca7-4d88-9f7a-33da753a8cc5.png">

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed
- [X] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License

- [X] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
