### PR TITLE
chore: add accurate error message when current active profile does not match a profile configured in the skill

### DIFF
--- a/src/utils/skillHelper.ts
+++ b/src/utils/skillHelper.ts
@@ -68,6 +68,15 @@ export function getSkillMetadataSrc(folderPath: string, profile: string): {skill
     skillPackageSrc = SKILL_FOLDER.SKILL_PACKAGE.NAME;
     return {skillPackageAbsPath, skillPackageSrc};
   }
+  
+  const allProfiles = R.keys(R.path(["profiles"], skillResource));
+  if(!allProfiles.includes(profile)){
+    throw logAskError(
+      `Currently active profile, '${profile}', was not found in 'ask-resources.json'. Profiles configured for this skill: '${allProfiles}'. ` + 
+      `Please ensure that the name of your active profile, '${profile}', matches a profile configured in 'ask-resources.json' and '.ask/ask-states.json'`,
+    );
+  }
+
   skillPackageSrc = R.path(["profiles", profile, "skillMetadata", "src"], skillResource);
   if (skillPackageSrc === undefined) {
     throw logAskError(


### PR DESCRIPTION
This fix improves the wording of a message that appears when the currently active profile does not match a profile configured in the `ask-resources.json` file in the currently opened skill. It also directs the user on what needs to be changed to resolve it.

Prior: "Failed to read skill package path due to AskError: Failed to get skill package path in ask-resources.json, please specify 'src' field in 'skillMetadata' under your profile name., the skill package watcher won't start."

Now: "Failed to read skill package path due to AskError: Currently active profile, 'default', was not found in 'ask-resources.json'. Profiles configured for this skill: 'acdl'. Please ensure that the name of your active profile, 'default', matches a profile configured in 'ask-resources.json' and '.ask/ask-states.json'., the skill package watcher won't start."

## Motivation and Context
The previous error message was misleading and did not point out the true cause of the issue.

## Testing
Manually tested

<img width="463" alt="image" src="https://user-images.githubusercontent.com/56455637/231024746-d065313d-b51c-47d2-99a2-184608747911.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
- [X] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License

- [X] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
