### PR TITLE
 fix: add framework for less frictional unit testing in ACDL language server, backfill hover tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -309,7 +309,7 @@
     "webpack-dev": "webpack --mode development --watch",
     "lint": "eslint src",
     "test-compile": "tsc -p ./",
-    "copyTestData": "cp -R ./test/mockSkill ./out/test",
+    "copyTestData": "cp -R ./test/mockSkill ./out/test && cp -R ./test/acdlServer/mockACDL ./out/test/acdlServer",
     "compile": "shx rm -rf ./out/ && shx rm -rf ./dist/ && tsc -p ./",
     "format": "prettier --write .",
     "watch": "tsc -watch -p ./",

--- a/src/acdlServer/acdlServer.ts
+++ b/src/acdlServer/acdlServer.ts
@@ -72,7 +72,7 @@ const getProjectUri = async (uri: string): Promise<string | void> => {
  * @param projectURI
  * @returns {Project} retrieve a Project that's already loaded from the "uriToProjects" dictionary
  */
-const getProject = (projectURI: string): Project => uriToProjects[projectURI];
+export const getProject = (projectURI: string): Project => uriToProjects[projectURI];
 
 /**
  * Get all Projects loaded/cached
@@ -145,10 +145,10 @@ export const addProject = async (uri: string): Promise<Project> => {
   return uriToProjects[projectUri];
 };
 
-export const enum UpdateProjectResult{
+export const enum UpdateProjectResult {
   UPDATED,
   ADDED,
-  NONE
+  NONE,
 }
 
 /**
@@ -173,7 +173,7 @@ export const updateProject = async (textDocument: TextDocument): Promise<UpdateP
     if (project) {
       project.update(file);
       return UpdateProjectResult.UPDATED;
-    } 
+    }
 
     await addProject(uri);
     return UpdateProjectResult.ADDED;

--- a/src/askContainer/commands/deviceRegistryCommand.ts
+++ b/src/askContainer/commands/deviceRegistryCommand.ts
@@ -12,8 +12,8 @@ import {DeviceRegistryWebview} from "../webViews/deviceRegistryWebview";
 export class DeviceRegistryCommand extends AbstractCommand<void> {
   private deviceRegistryWebview: DeviceRegistryWebview;
 
-  constructor(webview: DeviceRegistryWebview) {
-    super("askContainer.skillsConsole.deviceRegistry");
+  constructor(webview: DeviceRegistryWebview, commandOverride?: string) {
+    super(commandOverride ?? "askContainer.skillsConsole.deviceRegistry");
     this.deviceRegistryWebview = webview;
   }
 

--- a/test/acdlServer/acdlTestUtils.ts
+++ b/test/acdlServer/acdlTestUtils.ts
@@ -1,0 +1,69 @@
+import {Project, loadProject, loadProjectConfig} from "@alexa/acdl";
+import * as path from "path";
+import {workspace} from "vscode";
+import {MarkupContent, Position} from "vscode-languageclient";
+import {pathToFileURL} from "url";
+import {getFormalizedURI} from "../../src/acdlServer/utils";
+import {getHoverContent} from "../../src/acdlServer/acdlServer";
+
+const mockACDLPath = path.resolve(__dirname, "mockACDL");
+const mockACDLConversationsPath = path.resolve(mockACDLPath, "skill-package", "conversations");
+
+/**
+ * Loads the mockACDL project for testing.
+ * @returns the file URI location of the project if loaded successfully, `undefined` if not loaded successfully
+ */
+export async function initializeTestProject(): Promise<Project> {
+  const projectConfig = await loadProjectConfig(mockACDLPath);
+  const project = await loadProject(projectConfig);
+  return project;
+}
+
+/**
+ * Retrieves a Position representing the location of `text` in the file indicated by `testFileName`.
+ * @param text Text snippet to locate
+ * @param testFileName Name of the file to locate `text` in. This file is assumed to be in `./mockACDL/skill-package/conversations`.
+ * @returns Position representing the first found instance of `text` in `testFileName`.
+ */
+export async function getTextPosition(text: RegExp, testFileName: string): Promise<Position | undefined> {
+  const testFilePath = path.resolve(mockACDLPath, "skill-package", "conversations", testFileName);
+
+  const textDoc = await workspace.openTextDocument(testFilePath);
+  const match = textDoc.getText().match(text);
+
+  if (!match?.index) return undefined;
+
+  return textDoc.positionAt(match.index);
+}
+
+/**
+ * Retrieves hover text as if the user's cursor was at the first character of the first found instance of `text` in `testFileName`.
+ * @param text Text snippet representing where the hover cursor is
+ * @param testFileName ACDL file in which we should search for `text` and retrieve hover information
+ * @returns The resulting hover text when `text` is hovered
+ */
+export async function getHoverText(text: RegExp, testFileName: string): Promise<string> {
+  const testFilePath = path.resolve(mockACDLConversationsPath, testFileName);
+
+  let pos = await getTextPosition(text, testFilePath);
+  if (!pos) throw new Error(`Position of test text '${text.source}' not found in '${testFileName}'`);
+
+  // Increment character by one to better reflect desired location. E.g., without this, getting hover text for `weather` in `response(weather`
+  //   gets the hover text for the ( token, not weather.
+  pos = {
+    line: pos.line,
+    character: pos.character + 1,
+  };
+
+  const hoverResult = await getHoverContent({
+    textDocument: {
+      uri: getFormalizedURI(pathToFileURL(testFilePath).toString()),
+    },
+    position: pos,
+  });
+
+  const hoverText = hoverResult ? (hoverResult?.contents as MarkupContent).value : "";
+
+  // Trim ```acdl\n markup from beginning and \n``` markup from end
+  return hoverText.substring(8, hoverText.length - 4);
+}

--- a/test/acdlServer/hover.test.ts
+++ b/test/acdlServer/hover.test.ts
@@ -1,41 +1,99 @@
 import assert from "assert";
+import * as sinon from "sinon";
+import {Project} from "@alexa/acdl";
+import * as server from "../../src/acdlServer/acdlServer";
+import {getHoverText, initializeTestProject} from "./acdlTestUtils";
 import {formatComment, getCommentContent} from "../../src/acdlServer/hover";
 
 describe("Hover", () => {
-  it("should get empty string from jsdoc", () => {
-    const jsdoc = `/**
-        */`;
-    const result = getCommentContent(jsdoc);
-    const expected = ``;
-    assert.strictEqual(result, expected);
-  });
-  it("should get comment content from jsdoc", () => {
-    const jsdoc = `/**
-        * random text
-        */`;
-    const result = getCommentContent(jsdoc);
-    const expected = `random text`;
-    assert.strictEqual(result, expected);
+  describe("jsdoc", () => {
+    it("should get empty string from jsdoc", () => {
+      const jsdoc = `/**
+          */`;
+      const result = getCommentContent(jsdoc);
+      const expected = ``;
+      assert.strictEqual(result, expected);
+    });
+    it("should get comment content from jsdoc", () => {
+      const jsdoc = `/**
+          * random text
+          */`;
+      const result = getCommentContent(jsdoc);
+      const expected = `random text`;
+      assert.strictEqual(result, expected);
+    });
+
+    it("should get comment content from jsdoc - multiline", () => {
+      const jsdoc = `/**
+          * random text
+          * multiline comment
+          */`;
+      const result = getCommentContent(jsdoc);
+      const expected = `random text\nmultiline comment`;
+      assert.strictEqual(result, expected);
+    });
+
+    it("should highlight word after @param in jsdoc", () => {
+      const decl = {
+        comment: `/**
+          * @param arg arg description
+          */`,
+      };
+      const result = formatComment(decl);
+      const expected = ["@param - `arg` arg description  "];
+      assert.deepStrictEqual(result, expected);
+    });
   });
 
-  it("should get comment content from jsdoc - multiline", () => {
-    const jsdoc = `/**
-        * random text
-        * multiline comment
-        */`;
-    const result = getCommentContent(jsdoc);
-    const expected = `random text\nmultiline comment`;
-    assert.strictEqual(result, expected);
-  });
+  describe("definitions and declarations", () => {
+    const sbox = sinon.createSandbox();
+    const testFileName = "Weather.acdl";
+    let project: Project | undefined;
 
-  it("should highlight word after @param in jsdoc", () => {
-    const decl = {
-      comment: `/**
-        * @param arg arg description
-        */`,
-    };
-    const result = formatComment(decl);
-    const expected = ["@param - `arg` arg description  "];
-    assert.deepStrictEqual(result, expected);
+    before(async () => {
+      try {
+        project = await initializeTestProject();
+        sinon.stub(server, "getProject").returns(project);
+      } catch (err) {
+        throw new Error(`Failed to initialize ACDL test project: ${err.message}`);
+      }
+    });
+
+    after(() => sbox.restore());
+
+    it("should display the action declaration when hovering a user-defined action name", async () => {
+      const hoverText = await getHoverText(/getWeather\(/, testFileName);
+
+      const expectedText = "(action) getWeather(City cityName, DATE date) : WeatherResult";
+
+      assert.strictEqual(hoverText, expectedText);
+    });
+
+    it("should display the type definition when hovering a user-defined complex type", async () => {
+      const hoverText = await getHoverText(/WeatherResult getWea/, testFileName);
+
+      const expectedText = "type WeatherResult {\n City cityName\n NUMBER highTemp\n NUMBER lowTemp\n}";
+
+      assert.strictEqual(hoverText, expectedText);
+    });
+
+    it("should display the declaration for an `expect` call when hovering the expect keyword", async () => {
+      const hoverText = await getHoverText(/expect\(/, testFileName);
+
+      const expectedText = "(action) expect(Type<RequestAct> act, Event<CityAndDate> event) : CityAndDate";
+
+      assert.strictEqual(hoverText, expectedText);
+    });
+
+    it("should display the string contents of an APLA document when hovering an APLA template", async () => {
+      const hoverText = await getHoverText(/weather_apla, N/, testFileName);
+
+      const expectedText =
+        "(ResponseTemplate) weather_apla \n" +
+        '"In {weatherResult.cityName}, it\'s a high of {weatherResult.highTemp} degrees and a low of {weatherResult.lowTemp} degrees."' +
+        "\nwhen {weatherResult != null && payload.weatherResult.cityName != null && payload.weatherResult.highTemp != null && payload.weatherResult.lowTemp != null}";
+
+      assert.strictEqual(hoverText, expectedText);
+    });
   });
 });

--- a/test/acdlServer/mockACDL/ask-resources.json
+++ b/test/acdlServer/mockACDL/ask-resources.json
@@ -1,0 +1,10 @@
+{
+  "askcliResourcesVersion": "2020-03-31",
+  "profiles": {
+    "default": {
+      "skillMetadata": {
+        "src": "./skill-package"
+      }
+    }
+  }
+}

--- a/test/acdlServer/mockACDL/skill-package/conversations/Weather.acdl
+++ b/test/acdlServer/mockACDL/skill-package/conversations/Weather.acdl
@@ -1,0 +1,53 @@
+namespace com.weatherbot
+
+import com.amazon.alexa.ask.conversations.*
+import com.amazon.ask.types.builtins.AMAZON.*
+import com.amazon.alexa.schema.Nothing
+import prompts.weather_apla
+import prompts.request_city_apla
+import prompts.request_date_apla
+import prompts.request_city_date_apla
+
+type CityAndDate {
+    optional City cityName
+    optional DATE date
+}
+
+getWeatherEvent = utterances<CityAndDate>(
+    [
+        "What's the weather {date} in {cityName}",
+        "what is the weather {date}",
+        "How is the weather {date}",
+        "How is weather in {cityName} {date}",
+        "how is weather",
+        "can you please give me weather report for {date}"
+    ]
+)
+
+type WeatherResult {
+    City cityName
+    NUMBER highTemp
+    NUMBER lowTemp
+}
+
+type ResponsePayload {
+    WeatherResult weatherResult
+}
+
+action WeatherResult getWeather(City cityName, DATE date)
+
+dialog Nothing Weather {
+    sample {
+        weatherRequest = expect(Invoke, getWeatherEvent)
+
+        ensure(
+            RequestArguments {arguments = [getWeather.arguments.cityName], response = request_city_apla},
+            RequestArguments {arguments = [getWeather.arguments.date], response = request_date_apla},
+            RequestArguments {arguments = [getWeather.arguments.cityName, getWeather.arguments.date], response = request_city_date_apla}
+        )
+
+        weatherResult = getWeather(weatherRequest.cityName, weatherRequest.date)
+
+        response(weather_apla, Notify {actionName = getWeather}, payload = ResponsePayload {weatherResult = weatherResult})
+    }
+}

--- a/test/acdlServer/mockACDL/skill-package/interactionModels/custom/en-US.json
+++ b/test/acdlServer/mockACDL/skill-package/interactionModels/custom/en-US.json
@@ -1,0 +1,38 @@
+{
+    "interactionModel": {
+        "languageModel": {
+            "invocationName": "my weather bot",
+            "intents": [
+                {
+                    "name": "AMAZON.CancelIntent",
+                    "samples": []
+                },
+                {
+                    "name": "AMAZON.HelpIntent",
+                    "samples": []
+                },
+                {
+                    "name": "AMAZON.StopIntent",
+                    "samples": []
+                },
+                {
+                    "name": "GetWeatherIntent",
+                    "samples": [
+                        "what is the weather",
+                        "how is the weather",
+                        "tell me the weather"
+                    ]
+                },
+                {
+                    "name": "AMAZON.NavigateHomeIntent",
+                    "samples": []
+                },
+                {
+                    "name": "AMAZON.FallbackIntent",
+                    "samples": []
+                }
+            ],
+            "types": []
+        }
+    }
+}

--- a/test/acdlServer/mockACDL/skill-package/response/prompts/AlexaConversationsBye/document.json
+++ b/test/acdlServer/mockACDL/skill-package/response/prompts/AlexaConversationsBye/document.json
@@ -1,0 +1,21 @@
+{
+  "type": "APL-A",
+  "version": "0.1",
+  "mainTemplate": {
+    "parameters": [
+      "payload"
+    ],
+    "item": {
+      "type": "RandomSelector",
+      "description": "Change 'type' above to try different Selector Component Types like Sequential",
+      "items": [
+        {
+          "type": "Speech",
+          "contentType": "text",
+          "content": "Bye.",
+          "description": "Expand on 'items' array to add multiple prompts, use response template arguments by adding it to 'content' like this ${payload.input_argument_name} and add SSML by changing 'contentType' to 'SSML' and adding SSML to 'content' <amazon:effect name=\"whispered\">like that</amazon:effect>"
+        }
+      ]
+    }
+  }
+}

--- a/test/acdlServer/mockACDL/skill-package/response/prompts/AlexaConversationsNotifyFailure/document.json
+++ b/test/acdlServer/mockACDL/skill-package/response/prompts/AlexaConversationsNotifyFailure/document.json
@@ -1,0 +1,21 @@
+{
+  "type": "APL-A",
+  "version": "0.1",
+  "mainTemplate": {
+    "parameters": [
+      "payload"
+    ],
+    "item": {
+      "type": "RandomSelector",
+      "description": "Change 'type' above to try different Selector Component Types like Sequential",
+      "items": [
+        {
+          "type": "Speech",
+          "contentType": "text",
+          "content": "Sorry, there was an error in the request.",
+          "description": "Expand on 'items' array to add multiple prompts, use response template arguments by adding it to 'content' like this ${payload.input_argument_name} and add SSML by changing 'contentType' to 'SSML' and adding SSML to 'content' <amazon:effect name=\"whispered\">like that</amazon:effect>"
+        }
+      ]
+    }
+  }
+}

--- a/test/acdlServer/mockACDL/skill-package/response/prompts/AlexaConversationsOutOfDomain/document.json
+++ b/test/acdlServer/mockACDL/skill-package/response/prompts/AlexaConversationsOutOfDomain/document.json
@@ -1,0 +1,21 @@
+{
+  "type": "APL-A",
+  "version": "0.1",
+  "mainTemplate": {
+    "parameters": [
+      "payload"
+    ],
+    "item": {
+      "type": "RandomSelector",
+      "description": "Change 'type' above to try different Selector Component Types like Sequential",
+      "items": [
+        {
+          "type": "Speech",
+          "contentType": "text",
+          "content": "Sorry, I don't understand.",
+          "description": "Expand on 'items' array to add multiple prompts, use response template arguments by adding it to 'content' like this ${payload.input_argument_name} and add SSML by changing 'contentType' to 'SSML' and adding SSML to 'content' <amazon:effect name=\"whispered\">like that</amazon:effect>"
+        }
+      ]
+    }
+  }
+}

--- a/test/acdlServer/mockACDL/skill-package/response/prompts/AlexaConversationsProvideHelp/document.json
+++ b/test/acdlServer/mockACDL/skill-package/response/prompts/AlexaConversationsProvideHelp/document.json
@@ -1,0 +1,21 @@
+{
+  "type": "APL-A",
+  "version": "0.1",
+  "mainTemplate": {
+    "parameters": [
+      "payload"
+    ],
+    "item": {
+      "type": "RandomSelector",
+      "description": "Change 'type' above to try different Selector Component Types like Sequential",
+      "items": [
+        {
+          "type": "Speech",
+          "contentType": "text",
+          "content": "I can give you the weather report. Just say \"what's the weather\" to start.",
+          "description": "Expand on 'items' array to add multiple prompts, use response template arguments by adding it to 'content' like this ${payload.input_argument_name} and add SSML by changing 'contentType' to 'SSML' and adding SSML to 'content' <amazon:effect name=\"whispered\">like that</amazon:effect>"
+        }
+      ]
+    }
+  }
+}

--- a/test/acdlServer/mockACDL/skill-package/response/prompts/AlexaConversationsRequestMore/document.json
+++ b/test/acdlServer/mockACDL/skill-package/response/prompts/AlexaConversationsRequestMore/document.json
@@ -1,0 +1,21 @@
+{
+  "type": "APL-A",
+  "version": "0.1",
+  "mainTemplate": {
+    "parameters": [
+      "payload"
+    ],
+    "item": {
+      "type": "RandomSelector",
+      "description": "Change 'type' above to try different Selector Component Types like Sequential",
+      "items": [
+        {
+          "type": "Speech",
+          "contentType": "text",
+          "content": "What do you want to do.",
+          "description": "Expand on 'items' array to add multiple prompts, use response template arguments by adding it to 'content' like this ${payload.input_argument_name} and add SSML by changing 'contentType' to 'SSML' and adding SSML to 'content' <amazon:effect name=\"whispered\">like that</amazon:effect>"
+        }
+      ]
+    }
+  }
+}

--- a/test/acdlServer/mockACDL/skill-package/response/prompts/AlexaConversationsThankYou/document.json
+++ b/test/acdlServer/mockACDL/skill-package/response/prompts/AlexaConversationsThankYou/document.json
@@ -1,0 +1,21 @@
+{
+  "type": "APL-A",
+  "version": "0.1",
+  "mainTemplate": {
+    "parameters": [
+      "payload"
+    ],
+    "item": {
+      "type": "RandomSelector",
+      "description": "Change 'type' above to try different Selector Component Types like Sequential",
+      "items": [
+        {
+          "type": "Speech",
+          "contentType": "text",
+          "content": "Thank you.",
+          "description": "Expand on 'items' array to add multiple prompts, use response template arguments by adding it to 'content' like this ${payload.input_argument_name} and add SSML by changing 'contentType' to 'SSML' and adding SSML to 'content' <amazon:effect name=\"whispered\">like that</amazon:effect>"
+        }
+      ]
+    }
+  }
+}

--- a/test/acdlServer/mockACDL/skill-package/response/prompts/AlexaConversationsWelcome/document.json
+++ b/test/acdlServer/mockACDL/skill-package/response/prompts/AlexaConversationsWelcome/document.json
@@ -1,0 +1,21 @@
+{
+  "type": "APL-A",
+  "version": "0.1",
+  "mainTemplate": {
+    "parameters": [
+      "payload"
+    ],
+    "item": {
+      "type": "RandomSelector",
+      "description": "Change 'type' above to try different Selector Component Types like Sequential",
+      "items": [
+        {
+          "type": "Speech",
+          "contentType": "text",
+          "content": "Welcome to the weather bot, I can give you the weather report. Just say \"what's the weather\" to start.",
+          "description": "Expand on 'items' array to add multiple prompts, use response template arguments by adding it to 'content' like this ${payload.input_argument_name} and add SSML by changing 'contentType' to 'SSML' and adding SSML to 'content' <amazon:effect name=\"whispered\">like that</amazon:effect>"
+        }
+      ]
+    }
+  }
+}

--- a/test/acdlServer/mockACDL/skill-package/response/prompts/AlexaConversationsYouAreWelcome/document.json
+++ b/test/acdlServer/mockACDL/skill-package/response/prompts/AlexaConversationsYouAreWelcome/document.json
@@ -1,0 +1,21 @@
+{
+  "type": "APL-A",
+  "version": "0.1",
+  "mainTemplate": {
+    "parameters": [
+      "payload"
+    ],
+    "item": {
+      "type": "RandomSelector",
+      "description": "Change 'type' above to try different Selector Component Types like Sequential",
+      "items": [
+        {
+          "type": "Speech",
+          "contentType": "text",
+          "content": "You are welcome.",
+          "description": "Expand on 'items' array to add multiple prompts, use response template arguments by adding it to 'content' like this ${payload.input_argument_name} and add SSML by changing 'contentType' to 'SSML' and adding SSML to 'content' <amazon:effect name=\"whispered\">like that</amazon:effect>"
+        }
+      ]
+    }
+  }
+}

--- a/test/acdlServer/mockACDL/skill-package/response/prompts/request_city_apla/document.json
+++ b/test/acdlServer/mockACDL/skill-package/response/prompts/request_city_apla/document.json
@@ -1,0 +1,21 @@
+{
+  "type": "APL-A",
+  "version": "0.1",
+  "mainTemplate": {
+    "parameters": [
+      "payload"
+    ],
+    "item": {
+      "type": "RandomSelector",
+      "description": "Change 'type' above to try different Selector Component Types like Sequential",
+      "items": [
+        {
+          "type": "Speech",
+          "contentType": "text",
+          "content": "Which city?",
+          "description": "Expand on 'items' array to add multiple prompts, use response template arguments by adding it to 'content' like this ${payload.input_argument_name} and add SSML by changing 'contentType' to 'SSML' and adding SSML to 'content' <amazon:effect name=\"whispered\">like that</amazon:effect>"
+        }
+      ]
+    }
+  }
+}

--- a/test/acdlServer/mockACDL/skill-package/response/prompts/request_city_date_apla/document.json
+++ b/test/acdlServer/mockACDL/skill-package/response/prompts/request_city_date_apla/document.json
@@ -1,0 +1,21 @@
+{
+  "type": "APL-A",
+  "version": "0.1",
+  "mainTemplate": {
+    "parameters": [
+      "payload"
+    ],
+    "item": {
+      "type": "RandomSelector",
+      "description": "Change 'type' above to try different Selector Component Types like Sequential",
+      "items": [
+        {
+          "type": "Speech",
+          "contentType": "text",
+          "content": "Which city and for which date?",
+          "description": "Expand on 'items' array to add multiple prompts, use response template arguments by adding it to 'content' like this ${payload.input_argument_name} and add SSML by changing 'contentType' to 'SSML' and adding SSML to 'content' <amazon:effect name=\"whispered\">like that</amazon:effect>"
+        }
+      ]
+    }
+  }
+}

--- a/test/acdlServer/mockACDL/skill-package/response/prompts/request_date_apla/document.json
+++ b/test/acdlServer/mockACDL/skill-package/response/prompts/request_date_apla/document.json
@@ -1,0 +1,21 @@
+{
+  "type": "APL-A",
+  "version": "0.1",
+  "mainTemplate": {
+    "parameters": [
+      "payload"
+    ],
+    "item": {
+      "type": "RandomSelector",
+      "description": "Change 'type' above to try different Selector Component Types like Sequential",
+      "items": [
+        {
+          "type": "Speech",
+          "contentType": "text",
+          "content": "Which date?",
+          "description": "Expand on 'items' array to add multiple prompts, use response template arguments by adding it to 'content' like this ${payload.input_argument_name} and add SSML by changing 'contentType' to 'SSML' and adding SSML to 'content' <amazon:effect name=\"whispered\">like that</amazon:effect>"
+        }
+      ]
+    }
+  }
+}

--- a/test/acdlServer/mockACDL/skill-package/response/prompts/weather_apla/document.json
+++ b/test/acdlServer/mockACDL/skill-package/response/prompts/weather_apla/document.json
@@ -1,0 +1,22 @@
+{
+  "type": "APL-A",
+  "version": "0.1",
+  "mainTemplate": {
+    "parameters": [
+      "payload"
+    ],
+    "item": {
+      "type": "RandomSelector",
+      "description": "Change 'type' above to try different Selector Component Types like Sequential",
+      "items": [
+        {
+          "when": "${payload.weatherResult != null && payload.weatherResult.cityName != null && payload.weatherResult.highTemp != null && payload.weatherResult.lowTemp != null}",
+          "type": "Speech",
+          "contentType": "text",
+          "content": "In ${payload.weatherResult.cityName}, it's a high of ${payload.weatherResult.highTemp} degrees and a low of ${payload.weatherResult.lowTemp} degrees.",
+          "description": "Expand on 'items' array to add multiple prompts, use response template arguments by adding it to 'content' like this ${payload.input_argument_name} and add SSML by changing 'contentType' to 'SSML' and adding SSML to 'content' <amazon:effect name=\"whispered\">like that</amazon:effect>"
+        }
+      ]
+    }
+  }
+}

--- a/test/acdlServer/mockACDL/skill-package/skill.json
+++ b/test/acdlServer/mockACDL/skill-package/skill.json
@@ -1,0 +1,37 @@
+{
+  "manifest": {
+    "publishingInformation": {
+      "locales": {
+        "en-US": {
+          "summary": "Sample Short Description",
+          "examplePhrases": [
+            "Alexa open my weather bot",
+            "hello",
+            "help"
+          ],
+          "name": "template-weather-bot-blank",
+          "description": "Sample Full Description"
+        }
+      },
+      "isAvailableWorldwide": true,
+      "testingInstructions": "Sample Testing Instructions.",
+      "category": "KNOWLEDGE_AND_TRIVIA",
+      "distributionCountries": []
+    },
+    "apis": {
+      "custom": {
+        "dialogManagement": {
+          "sessionStartDelegationStrategy": {
+            "target": "AMAZON.Conversations"
+          },
+          "dialogManagers": [
+            {
+              "type": "AMAZON.Conversations"
+            }
+          ]
+        }
+      }
+    },
+    "manifestVersion": "1.0"
+  }
+}

--- a/test/askContainer/commands/deviceRegistry.test.ts
+++ b/test/askContainer/commands/deviceRegistry.test.ts
@@ -28,8 +28,8 @@ describe("Command askContainer.skillsConsole.deviceRegistry", () => {
 
   it("Should show the view when executed", async () => {
     const showViewSpy = sinon.spy();
-    command = new DeviceRegistryCommand({showView: showViewSpy} as any);
 
+    command = new DeviceRegistryCommand({showView: showViewSpy} as any, "askContainer.skillsConsole.deviceRegistryTest");
     /*
         undefined argument due to
 
@@ -38,7 +38,7 @@ describe("Command askContainer.skillsConsole.deviceRegistry", () => {
         and passes that as a parameter when invoking the command. 
 
     */
-    await vscode.commands.executeCommand("askContainer.skillsConsole.deviceRegistry", undefined);
+    await vscode.commands.executeCommand("askContainer.skillsConsole.deviceRegistryTest", undefined);
 
     assert.ok(showViewSpy.called);
   });


### PR DESCRIPTION
This update introduces some utilities in `acdlTestUtils.ts` that offer an easier way to write unit tests for the ACDL language server. ACDL test files can be added to the `test/acdlServer/mockACDL/skill-package/conversations` directory, and rapid tests can be written against those files. All you need to give the utility is the name of a test ACDL file and a snippet of unique text within that ACDL file to indicate the position of the user's cursor. It will dig up what the current hover behavior is at that location and compare it with what the expected hover text is.

The utilities will be expanded in the future to cover autocomplete suggestions and getDefinition requests.

## Motivation and Context
Writing a large amount of useful tests for the language server is tedious, this aims to reduce that tedium and get valuable tests more quickly.

## Testing
Manual as well as unit tests, all passing.

<img width="852" alt="image" src="https://user-images.githubusercontent.com/56455637/231320289-90cdd5db-5da2-4b7a-bf88-7b7744779981.png">


## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License

- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
