### PR TITLE
fix: viewport.mode always showing hub

### DIFF
--- a/media/previewApl/aplRenderUtils.js
+++ b/media/previewApl/aplRenderUtils.js
@@ -14,7 +14,7 @@
  * @param {object} onSendEvent
  */
 
-async function loadAplDoc(renderer, apl, datasources, deviceConfig, fatherDiv, onSendEvent) {
+async function loadAplDoc(renderer, apl, datasources, deviceConfig, deviceMode ,fatherDiv, onSendEvent) {
   if (renderer) {
     renderer.destroy();
     renderer = undefined;
@@ -50,6 +50,7 @@ async function loadAplDoc(renderer, apl, datasources, deviceConfig, fatherDiv, o
       mappingKey: "auth-id",
       writeKeys: ["auth-banana", "auth-id"],
     },
+    mode: deviceMode?.toUpperCase(),
     utcTime: Date.now(),
     localTimeAdjustment: -new Date().getTimezoneOffset() * 60 * 1000,
   };

--- a/media/previewApl/previewApl.js
+++ b/media/previewApl/previewApl.js
@@ -16,7 +16,7 @@ window.onload = function () {
 window.addEventListener("message", (event) => {
   const message = event.data; // The json data that the extension sent
   const sendCommandEvent = (commandEvent) => {};
-  loadAplDoc(renderer, message.document, message.datasources, JSON.parse(message.viewport), EMPTY_STRING, sendCommandEvent);
+  loadAplDoc(renderer, message.document, message.datasources, JSON.parse(message.viewport), message?.mode,EMPTY_STRING, sendCommandEvent);
 });
 
 function initialize() {

--- a/media/simulateSkill/simulateSkill.js
+++ b/media/simulateSkill/simulateSkill.js
@@ -452,7 +452,7 @@ async function updateAplViewPort(document, dataSource, viewport) {
       });
     }
   };
-  await loadAplDoc(renderer, document, dataSource, viewport, APL_VIEW_BOX, sendCommandEvent);
+  await loadAplDoc(renderer, document, dataSource, viewport, viewport?.mode, APL_VIEW_BOX, sendCommandEvent);
   saveElementState(INFO_BOX);
 }
 

--- a/src/aplContainer/commands/changeViewportProfile.ts
+++ b/src/aplContainer/commands/changeViewportProfile.ts
@@ -11,7 +11,7 @@ import {Logger} from "../../logger";
 import {AbstractCommand} from "../../runtime";
 import {EXTENSION_COMMAND_CONFIG} from "../config/configuration";
 import {ERROR_MESSAGES} from "../constants/messages";
-import {getViewportCharacteristicsFromViewPort} from "../utils/viewportProfileHelper";
+import {DEFAULT_VIEWPORT_MODE, getViewportCharacteristicsFromViewPort} from "../utils/viewportProfileHelper";
 import {AplPreviewWebView} from "../webViews/aplPreviewWebView";
 
 export class ChangeViewportProfileCommand extends AbstractCommand<void> {
@@ -132,9 +132,9 @@ export class ChangeViewportProfileCommand extends AbstractCommand<void> {
     if (viewportToChange) {
       const viewport = getViewportCharacteristicsFromViewPort({
         ...viewportToChange,
-        shape: viewportProfile.shape,
+        shape: viewportProfile.shape.toUpperCase()
       } as IViewport);
-      this.aplPreviewWebView.changeViewport(viewport);
+      this.aplPreviewWebView.changeViewport(viewport,viewportProfile?.mode || DEFAULT_VIEWPORT_MODE);
       return true;
     }
     return false;

--- a/src/aplContainer/utils/viewportProfileHelper.ts
+++ b/src/aplContainer/utils/viewportProfileHelper.ts
@@ -4,7 +4,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *--------------------------------------------------------------------------------------------*/
 
-import {getDefaultViewport, IViewport, ViewportShape} from "apl-suggester";
+import {getDefaultViewport, IViewport, ViewportMode, ViewportShape} from "apl-suggester";
 
 /**
  * DP -> Pixel convert
@@ -41,3 +41,4 @@ export function getViewportCharacteristicsFromViewPort(activeViewport: IViewport
 
 export const DEFAULT_VIEWPORT_CHARACTERISTICS = getViewportCharacteristicsFromViewPort(getDefaultViewport());
 export const DEFAULT_VIEWPORT_NAME = "Echo Show 1";
+export const DEFAULT_VIEWPORT_MODE = ViewportMode.HUB;

--- a/src/aplContainer/webViews/aplPreviewWebView.ts
+++ b/src/aplContainer/webViews/aplPreviewWebView.ts
@@ -8,7 +8,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as R from "ramda";
 import * as jsonfile from "jsonfile";
-import {IViewport} from "apl-suggester";
+import {IViewport,ViewportMode} from "apl-suggester";
 import {AbstractWebView} from "../../runtime";
 import {ViewLoader} from "../../utils/webViews/viewLoader";
 import {APL_DOCUMENT_FILE_PATH, DATASOURCES_FILE_PATH, DATA_PATH_REGEX, DOCUMENT_PATH_REGEX} from "../config/configuration";
@@ -18,6 +18,7 @@ import {Logger} from "../../logger";
 export class AplPreviewWebView extends AbstractWebView {
   private loader: ViewLoader;
   private viewport: IViewport;
+  private mode: ViewportMode;
   private context: vscode.ExtensionContext;
   private document: string | undefined;
   private datasources: string | undefined;
@@ -42,10 +43,11 @@ export class AplPreviewWebView extends AbstractWebView {
    *
    * @memberOf AplPreviewWebView
    */
-  public changeViewport(viewport: IViewport) {
+  public changeViewport(viewport: IViewport,mode: ViewportMode) {
     Logger.verbose(`Calling method: ${this.viewId}.changeViewport, args: `, viewport.toString());
     if (!R.equals(this.viewport, viewport)) {
       this.viewport = viewport;
+      this.mode = mode;
       this.postMessage();
     }
   }
@@ -103,6 +105,7 @@ export class AplPreviewWebView extends AbstractWebView {
       document: this.document,
       datasources: this.datasources,
       viewport: JSON.stringify(this.viewport),
+      mode: this.mode
     });
   }
 


### PR DESCRIPTION
There is currently an issue with the apl preview. If the user uses `${viewport.mode}` in their APL document, it always shows "hub" irrespective of what device/viewport is being used t preview the APL document. 

### Steps to Reproduce
1. Copy the [sample APL document](https://apl.ninja/document/Rahul/pvJORVSqg0HIlirer7qiuzxrmB4rurOM)
2. Use the VS Code plugin to preview above document in different viewports
3. The mode is always "hub" 

This PR fixes the above issue.

## Description
The bug was that the viewport mode was not being passed as an option to web viewhost for rendering. By default if no mode is provided, when rendering web viewhost returns "hub". The major change is adding an extra parameter to the function that renders the APL doc and updating it's invocations by passing the viewport mode. 

## Motivation and Context
This bug doesn't exist on authoring tool and hence we need to fix it in the vs code plugin as well.


## Testing
I ran `npm run test`. Below is the output

```
  122 passing (4s)

  10 pending
```

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License

- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
