### PR TITLE
feat: set python 3.8 as default hosted skill python runtime version

### DIFF
--- a/media/createSkill/createSkill.html
+++ b/media/createSkill/createSkill.html
@@ -86,7 +86,7 @@
                             <span>With Alexa-Hosted skills you get free hosting with AWS Lambda (up to the AWS Free Tier). <a href='https://developer.amazon.com/en-US/docs/alexa/hosted-skills/build-a-skill-end-to-end-using-an-alexa-hosted-skill.html'>Learn more</a></span>
                             <select id="runtime" name="runtime">
                                 <option value='NODE_16_X'>Alexa-Hosted (Node.js)</option>
-                                <option value='PYTHON_3_7'>Alexa-Hosted (Python)</option>
+                                <option value='PYTHON_3_8'>Alexa-Hosted (Python)</option>
                             </select>
                             <br/><br/>
                             <label for="skillRegion">Hosting region</label><br/>


### PR DESCRIPTION

## Description
This Change allows the usage of python3.8 as default python run time for Alexa Hosted Skills. 

## Motivation and Context

## Testing
This change is being released after testing in beta and gamma testing.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License

- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
