### PR TITLE
Bump up APL Suggester and Viewhost to version 2024.1

### DIFF
--- a/media/previewApl/previewApl.html
+++ b/media/previewApl/previewApl.html
@@ -10,7 +10,7 @@
     content="default-src https: data:; img-src https: data:; script-src vscode-resource: https: data: 'unsafe-inline' 'unsafe-eval'; style-src vscode-resource: 'unsafe-inline';" />
     
     <title>APL Preview</title>
-    <script src="https://d2o906d8ln7ui1.cloudfront.net/apl-wasm-2023.3.js"></script>
+    <script src="https://d2o906d8ln7ui1.cloudfront.net/apl-wasm-2024.1.js"></script>
     <script>window.AplRenderer || document.write('<script src="${customJavascript}"><\\/script>')</script> 
     <script src="${aplRenderUtils}"></script>
     <script src="${javascript}"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2180,9 +2180,9 @@
       "integrity": "sha512-+ZvkforUDGqwU1npZYIMPuszsInIypxL81rFAsCGDs9CRhAEWO6s3rpO+TfJk9mgUgxKNMnSVQa/npPPD4gJXw=="
     },
     "@types/core-js": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/@types/core-js/-/core-js-2.5.5.tgz",
-      "integrity": "sha512-C4vwOHrhsvxn7UFyk4NDQNUpgNKdWsT/bL39UWyD75KSEOObZSKa9mYDOCM5FGeJG2qtbG0XiEbUKND2+j0WOg=="
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@types/core-js/-/core-js-2.5.8.tgz",
+      "integrity": "sha512-VgnAj6tIAhJhZdJ8/IpxdatM8G4OD3VWGlp6xIxUGENZlpbob9Ty4VVdC1FIEp0aK6DBscDDjyzy5FB60TuNqg=="
     },
     "@types/eslint": {
       "version": "8.21.3",
@@ -2884,16 +2884,16 @@
       }
     },
     "apl-suggester": {
-      "version": "2023.3.0",
-      "resolved": "https://registry.npmjs.org/apl-suggester/-/apl-suggester-2023.3.0.tgz",
-      "integrity": "sha512-hSm/acnRyDzoH55CfL4664cJU7GpGedgQGju2e/WdInjnaaNb8yBM10FRYY1vdqFpfiUsDQgruzTXBXZLlz8Tw==",
+      "version": "2024.1.0",
+      "resolved": "https://registry.npmjs.org/apl-suggester/-/apl-suggester-2024.1.0.tgz",
+      "integrity": "sha512-wYca6/U0V8nPi5kJ2EWuxikoWz4yC/HsWUDpSR1jGCsfi1smWO9+c9iUWIhDFfxm4JtWHUdBmKAXj3zbH61IgA==",
       "requires": {
         "@types/chai": "3.5.x",
         "@types/core-js": "2.5.x",
         "@types/node": "12.0.x",
         "@types/sinon": "2.2.x",
         "ajv": "^7.2.4",
-        "axios": "0.27.2",
+        "axios": "1.6.0",
         "immutable": "4.1.0",
         "jsdom-global": "3.0.x",
         "ts-node": "3.3.x",
@@ -2922,12 +2922,13 @@
           }
         },
         "axios": {
-          "version": "0.27.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
+          "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
           "requires": {
-            "follow-redirects": "^1.14.9",
-            "form-data": "^4.0.0"
+            "follow-redirects": "^1.15.0",
+            "form-data": "^4.0.0",
+            "proxy-from-env": "^1.1.0"
           }
         },
         "form-data": {
@@ -2970,9 +2971,9 @@
       }
     },
     "apl-viewhost-web": {
-      "version": "2023.3.0",
-      "resolved": "https://registry.npmjs.org/apl-viewhost-web/-/apl-viewhost-web-2023.3.0.tgz",
-      "integrity": "sha512-ZNYA/wMFzRjhKCF0Sxj+PpuWHvBXR5Wn50ce6mWzY0C+s6/eRen3TPLLNKCLzzpNGwDedwMJZ5Ip3GEyRQYi/A=="
+      "version": "2024.1.0",
+      "resolved": "https://registry.npmjs.org/apl-viewhost-web/-/apl-viewhost-web-2024.1.0.tgz",
+      "integrity": "sha512-OYcxCyXPRPyhfEi2nV9bF66yEq1kLQ7azYltVju4jtKVbHHKVMxIz1Yaf2exUwUoh8X97d8zKtanOETEb3hfHQ=="
     },
     "append-buffer": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -367,8 +367,8 @@
   "dependencies": {
     "@alexa/acdl": "^0.3.3",
     "adm-zip": "0.5.10",
-    "apl-suggester": "^2023.3.0",
-    "apl-viewhost-web": "^2023.3.0",
+    "apl-suggester": "^2024.1.0",
+    "apl-viewhost-web": "^2024.1.0",
     "ask-smapi-model": "^1.14.0",
     "ask-smapi-sdk": "^1.2.2",
     "async-retry": "^1.3.1",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Upgrade apl-suggester and apl-viewhost-web to version 2024.1

## Motivation and Context
This PR updates VS Code Extension to use the latest version of suggester and viewhost.

## Testing
Test locally by running npm i and then running and debugging the extension for APL related features.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License

- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
