### PR TITLE
Bump up APL Suggester and Viewhost to version 2024.2

### DIFF
--- a/media/previewApl/previewApl.html
+++ b/media/previewApl/previewApl.html
@@ -10,7 +10,7 @@
     content="default-src https: data:; img-src https: data:; script-src vscode-resource: https: data: 'unsafe-inline' 'unsafe-eval'; style-src vscode-resource: 'unsafe-inline';" />
     
     <title>APL Preview</title>
-    <script src="https://d2o906d8ln7ui1.cloudfront.net/apl-wasm-2024.1.js"></script>
+    <script src="https://d2o906d8ln7ui1.cloudfront.net/apl-wasm-2024.2.js"></script>
     <script>window.AplRenderer || document.write('<script src="${customJavascript}"><\\/script>')</script> 
     <script src="${aplRenderUtils}"></script>
     <script src="${javascript}"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2884,9 +2884,9 @@
       }
     },
     "apl-suggester": {
-      "version": "2024.1.0",
-      "resolved": "https://registry.npmjs.org/apl-suggester/-/apl-suggester-2024.1.0.tgz",
-      "integrity": "sha512-wYca6/U0V8nPi5kJ2EWuxikoWz4yC/HsWUDpSR1jGCsfi1smWO9+c9iUWIhDFfxm4JtWHUdBmKAXj3zbH61IgA==",
+      "version": "2024.2.0",
+      "resolved": "https://registry.npmjs.org/apl-suggester/-/apl-suggester-2024.2.0.tgz",
+      "integrity": "sha512-RdoiM7hcfZtTQTGGp8Em32ihTp6nmyCO3y5UuOKNBP5veTq4XhNg7EvnQnep77jR+5uuLJdvsjlK4ph8Umc0Qw==",
       "requires": {
         "@types/chai": "3.5.x",
         "@types/core-js": "2.5.x",
@@ -2971,9 +2971,9 @@
       }
     },
     "apl-viewhost-web": {
-      "version": "2024.1.0",
-      "resolved": "https://registry.npmjs.org/apl-viewhost-web/-/apl-viewhost-web-2024.1.0.tgz",
-      "integrity": "sha512-OYcxCyXPRPyhfEi2nV9bF66yEq1kLQ7azYltVju4jtKVbHHKVMxIz1Yaf2exUwUoh8X97d8zKtanOETEb3hfHQ=="
+      "version": "2024.2.0",
+      "resolved": "https://registry.npmjs.org/apl-viewhost-web/-/apl-viewhost-web-2024.2.0.tgz",
+      "integrity": "sha512-HRTynxLsT/Iq/90bJKXJImK5c1wfuUSKMEc3KJbckd3RJbq4M8tACorDeXuoZnqWRSrBNMYlyfz+OsyXP+Ga2A=="
     },
     "append-buffer": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -367,8 +367,8 @@
   "dependencies": {
     "@alexa/acdl": "^0.3.3",
     "adm-zip": "0.5.10",
-    "apl-suggester": "^2024.1.0",
-    "apl-viewhost-web": "^2024.1.0",
+    "apl-suggester": "^2024.2.0",
+    "apl-viewhost-web": "^2024.2.0",
     "ask-smapi-model": "^1.14.0",
     "ask-smapi-sdk": "^1.2.2",
     "async-retry": "^1.3.1",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Upgrade apl-suggester and apl-viewhost-web to version 2024.2

## Motivation and Context
This PR updates VS Code Extension to use the latest version of suggester and viewhost.

## Testing
Test locally by running npm i and then running and debugging the extension for APL related features.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License

- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
