### PR TITLE
fix: vscode workspaceState bug workaround

### DIFF
--- a/src/utils/workspaceHelper.ts
+++ b/src/utils/workspaceHelper.ts
@@ -31,7 +31,7 @@ export async function findSkillFoldersInWs(): Promise<vscode.Uri[]> {
   const askResources = await vscode.workspace.findFiles("**/ask-resources.json");
   const skillFolders: vscode.Uri[] = [];
   askResources.forEach((resourceFileUri) => {
-    skillFolders.push(vscode.Uri.file(path.dirname(resourceFileUri.fsPath)));
+    skillFolders.push(vscode.Uri.file(path.dirname(resourceFileUri.fsPath)).toJSON());
   });
   return skillFolders;
 }
@@ -40,7 +40,7 @@ export function getSkillFolderInWs(context: vscode.ExtensionContext): vscode.Uri
   Logger.verbose("Calling method: getSkillFolderInWs");
   const skillFolders: vscode.Uri[] | undefined = context.workspaceState.get(EXTENSION_STATE_KEY.WS_SKILLS);
   if (doesWorkSpaceExist() && skillFolders) {
-    return skillFolders.length > 0 ? skillFolders[0] : undefined;
+    return skillFolders.length > 0 ? vscode.Uri.from(skillFolders[0]) : undefined;
   }
   return undefined;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
See #301 for the writeup, microsoft/vscode@06c07d24efd3aa76412a55b0bd4f3833c901a00e introduces a subtle backwards compatibility issue which causes the extension to be unusable

## Motivation and Context
Fixes #301, which makes the extension completely unusable in VS Code versions after 1.96.4

## Testing
This has been tested on VS Code version 1.101.14098

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed
- [X] My commit message follows [Conventional Commit Guideline](https://conventionalcommits.org/)

## License

- [X] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
